### PR TITLE
Spacy tokenizer

### DIFF
--- a/deeppavlov/__init__.py
+++ b/deeppavlov/__init__.py
@@ -35,7 +35,7 @@ import deeppavlov.models.trackers.hcn_et
 import deeppavlov.models.preprocessors.str_lower
 import deeppavlov.models.preprocessors.squad_preprocessor
 import deeppavlov.models.ner.ner
-import deeppavlov.models.tokenizers.spacy_tokenizer
+import deeppavlov.models.tokenizers.stream_spacy_tokenizer
 import deeppavlov.models.tokenizers.split_tokenizer
 import deeppavlov.models.squad.squad
 import deeppavlov.skills.go_bot.bot

--- a/deeppavlov/models/tokenizers/spacy_tokenizer.py
+++ b/deeppavlov/models/tokenizers/spacy_tokenizer.py
@@ -145,11 +145,14 @@ class SpacyTokenizer(Component):
         :param alphas_only: should filter numeric and alpha-numeric types or not
         :return: filtered list of tokens/lemmas
         """
-        _alphas_only = self.alphas_only or alphas_only
+        if self.alphas_only is None:
+            _alphas_only = alphas_only
+        else:
+            _alphas_only = self.alphas_only
 
         if _alphas_only:
-            filter_fn = lambda x: x.isalpha() and x not in self._stopwords
+            filter_fn = lambda x: x.isalpha() and not x.isspace() and x not in self.stopwords
         else:
-            filter_fn = lambda x: x not in self._stopwords
+            filter_fn = lambda x: not x.isspace() and x not in self.stopwords
 
         return list(filter(filter_fn, items))

--- a/deeppavlov/models/tokenizers/stream_spacy_tokenizer.py
+++ b/deeppavlov/models/tokenizers/stream_spacy_tokenizer.py
@@ -14,13 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from itertools import chain
 from typing import List, Generator, Any, Tuple
 
 import spacy
-from spacy.tokenizer import Tokenizer
-from spacy.lemmatizer import Lemmatizer
-from spacy.lang.en import LEMMA_INDEX, LEMMA_EXC, LEMMA_RULES, LOOKUP
-# from sklearn.feature_extraction.stop_words import ENGLISH_STOP_WORDS
+from spacy.lang.en import English
+from sklearn.feature_extraction.stop_words import ENGLISH_STOP_WORDS
 
 from deeppavlov.core.models.component import Component
 from deeppavlov.core.common.registry import register
@@ -30,38 +29,40 @@ from deeppavlov.core.common.log import get_logger
 logger = get_logger(__name__)
 
 
-@register('spacy_tokenizer')
-class SpacyTokenizer(Component):
+@register('stream_spacy_tokenizer')
+class StreamSpacyTokenizer(Component):
     """
-    Tokenize or tokenize a list of documents.
+    Tokenize or lemmatize a list of documents.
     Return list of tokens or lemmas, without sentencizing.
     Works only for English language.
     """
 
-    def __init__(self, disable: list = None, stopwords: list = None, batch_size: int = None,
-                 ngram_range: Tuple[int, int] = None, lemmas=False, lowercase: bool = None,
-                 alphas_only: bool = None, **kwargs):
+    def __init__(self, disable: list = None, stopwords: list = None,
+                 batch_size: int = None, ngram_range: List[int] = None, lemmas=False,
+                 n_threads: int = None, lowercase: bool = None, alphas_only: bool = None, **kwargs):
         """
         :param disable: pipeline processors to omit; if nothing should be disabled,
          pass an empty list
         :param stopwords: a set of words to skip
         :param batch_size: a batch size for internal spaCy multi-threading
         :param ngram_range: range for producing ngrams, ex. for unigrams + bigrams should be set to
-        (1, 2), for bigrams only should be set to (2, 2)
+        [1, 2], for bigrams only should be set to [2, 2]
         :param lemmas: weather to perform lemmatizing or not while tokenizing, currently works only
         for the English language
         :param n_threads: a number of threads for internal spaCy multi-threading
         """
         if disable is None:
             disable = ['parser', 'ner']
-        self._stopwords = stopwords or []
-
+        if ngram_range is None:
+            ngram_range = [1, 1]
+        self.stopwords = stopwords or []
         self.model = spacy.load('en', disable=disable)
-        self.tokenizer = Tokenizer(self.model.vocab)
-        self.lemmatizer = Lemmatizer(LEMMA_INDEX, LEMMA_EXC, LEMMA_RULES, LOOKUP)
+        self.model.add_pipe(self.model.create_pipe('sentencizer'))
+        self.tokenizer = English().Defaults.create_tokenizer(self.model)
         self.batch_size = batch_size
-        self.ngram_range = ngram_range
+        self.ngram_range = tuple(ngram_range)  # cast JSON array to tuple
         self.lemmas = lemmas
+        self.n_threads = n_threads
         self.lowercase = lowercase
         self.alphas_only = alphas_only
 
@@ -76,64 +77,69 @@ class SpacyTokenizer(Component):
         raise TypeError(
             "StreamSpacyTokenizer.__call__() is not implemented for `{}`".format(type(batch[0])))
 
-    @property
-    def stopwords(self):
-        return self._stopwords
-
-    @stopwords.setter
-    def stopwords(self, stopwords: List[str]):
-        self._stopwords = stopwords
-
-    def _tokenize(self, data: List[str], ngram_range=(1, 1),
-                 lowercase=True) -> Generator[List[str], Any, None]:
+    def _tokenize(self, data: List[str], ngram_range=(1, 1), batch_size=10000, n_threads=1,
+                  lowercase=True) -> Generator[List[str], Any, None]:
         """
         Tokenize a list of documents.
         :param data: a list of documents to process
         :param ngram_range: range for producing ngrams, ex. for unigrams + bigrams should be set to
         (1, 2), for bigrams only should be set to (2, 2)
+        :param batch_size: the number of documents to process at once;
+        improves the spacy 'pipe' performance; shouldn't be too small
+        :param n_threads: a number of threads for parallel computing; doesn't work good
+         on a standard Python
         :param lowercase: whether to perform lowercasing or not
         :return: a single processed doc generator
         """
         # DEBUG
         # size = len(data)
-
+        _batch_size = self.batch_size or batch_size
         _ngram_range = self.ngram_range or ngram_range
+        _n_threads = self.n_threads or n_threads
 
         if self.lowercase is None:
             _lowercase = lowercase
         else:
             _lowercase = self.lowercase
 
-        for i, doc in enumerate(data):
-            spacy_doc = self.model(doc)
-            # logger.debug("Tokenize doc {} from {}".format(i, size))
+        # print(_lowercase)
+
+        for i, doc in enumerate(
+                self.tokenizer.pipe(data, batch_size=_batch_size, n_threads=_n_threads)):
+            # DEBUG
+            # logger.info("Tokenize doc {} from {}".format(i, size))
             if _lowercase:
-                tokens = [t.lower_ for t in spacy_doc]
+                tokens = [t.lower_ for t in doc]
             else:
-                tokens = [t.text for t in spacy_doc]
+                tokens = [t.text for t in doc]
             filtered = self._filter(tokens)
             processed_doc = ngramize(filtered, ngram_range=_ngram_range)
             yield from processed_doc
 
-    def _lemmatize(self, data: List[str], ngram_range=(1, 1)) -> \
+    def _lemmatize(self, data: List[str], ngram_range=(1, 1), batch_size=10000, n_threads=1) -> \
             Generator[List[str], Any, None]:
         """
         Lemmatize a list of documents.
         :param data: a list of documents to process
         :param ngram_range: range for producing ngrams, ex. for unigrams + bigrams should be set to
         (1, 2), for bigrams only should be set to (2, 2)
+        :param batch_size: the number of documents to process at once;
+        improves the spacy 'pipe' performance; shouldn't be too small
+        :param n_threads: a number of threads for parallel computing; doesn't work good
+         on a standard Python
         :return: a single processed doc generator
         """
         # DEBUG
         # size = len(data)
-
+        _batch_size = self.batch_size or batch_size
         _ngram_range = self.ngram_range or ngram_range
+        _n_threads = self.n_threads or n_threads
 
-        for i, doc in enumerate(data):
-            spacy_doc = self.model(doc)
-            # logger.debug("Lemmatize doc {} from {}".format(i, size))
-            tokens = [t.lower_ for t in spacy_doc]
-            lemmas = [self.lemmatizer.lookup(word) for word in tokens]
+        for i, doc in enumerate(
+                self.model.pipe(data, batch_size=_batch_size, n_threads=_n_threads)):
+            # DEBUG
+            # logger.info("Lemmatize doc {} from {}".format(i, size))
+            lemmas = chain.from_iterable([sent.lemma_.split() for sent in doc.sents])
             filtered = self._filter(lemmas)
             processed_doc = ngramize(filtered, ngram_range=_ngram_range)
             yield from processed_doc
@@ -145,11 +151,17 @@ class SpacyTokenizer(Component):
         :param alphas_only: should filter numeric and alpha-numeric types or not
         :return: filtered list of tokens/lemmas
         """
-        _alphas_only = self.alphas_only or alphas_only
+        if self.alphas_only is None:
+            _alphas_only = alphas_only
+        else:
+            _alphas_only = self.alphas_only
 
         if _alphas_only:
-            filter_fn = lambda x: x.isalpha() and x not in self._stopwords
+            filter_fn = lambda x: x.isalpha() and not x.isspace() and x not in self.stopwords
         else:
-            filter_fn = lambda x: x not in self._stopwords
+            filter_fn = lambda x: not x.isspace() and x not in self.stopwords
 
         return list(filter(filter_fn, items))
+
+    def set_stopwords(self, stopwords):
+        self.stopwords = stopwords

--- a/deeppavlov/models/vectorizers/hashing_tfidf_vectorizer.py
+++ b/deeppavlov/models/vectorizers/hashing_tfidf_vectorizer.py
@@ -22,7 +22,7 @@ from scipy import sparse
 import numpy as np
 from sklearn.utils import murmurhash3_32
 
-from deeppavlov.models.tokenizers.spacy_tokenizer import StreamSpacyTokenizer
+from deeppavlov.models.tokenizers.stream_spacy_tokenizer import StreamSpacyTokenizer
 from deeppavlov.core.models.component import Component
 from deeppavlov.core.models.serializable import Serializable
 from deeppavlov.core.common.log import get_logger

--- a/deeppavlov/skills/go_bot/bot.py
+++ b/deeppavlov/skills/go_bot/bot.py
@@ -28,7 +28,7 @@ from deeppavlov.models.embedders.fasttext_embedder import FasttextEmbedder
 from deeppavlov.models.encoders.bow import BoWEncoder
 from deeppavlov.models.classifiers.intents.intent_model import KerasIntentModel
 from deeppavlov.models.ner.slotfill import DstcSlotFillingNetwork
-from deeppavlov.models.tokenizers.spacy_tokenizer import StreamSpacyTokenizer
+from deeppavlov.models.tokenizers.stream_spacy_tokenizer import StreamSpacyTokenizer
 from deeppavlov.models.trackers.default_tracker import DefaultTracker
 from deeppavlov.skills.go_bot.network import GoalOrientedBotNetwork
 from deeppavlov.skills.go_bot.templates import Templates, DualTemplate


### PR DESCRIPTION
Non-streaming SpaCy tokenizer. Add it because some people complain about slow working of streaming tokenizer. On some machines SpaCy threads behave oddly.
* non streaming spacy tokenizer
* rename spacy_tokenizer.py -> streaming_spacy_tokenizer.py