### PR TITLE
refactor: change api keyword

### DIFF
--- a/utils/server_utils/server_config.json
+++ b/utils/server_utils/server_config.json
@@ -3,7 +3,7 @@
     "host": "0.0.0.0",
     "port": 5000,
     "model_endpoint": "/model",
-    "model_args_names": ["context"]
+    "model_args_names": ["text1"]
   },
   "model_defaults": {
     "DstcSlotFillingNetwork": {

--- a/utils/server_utils/server_config.json
+++ b/utils/server_utils/server_config.json
@@ -40,7 +40,7 @@
       "host": "",
       "port": "",
       "model_endpoint": "/squad",
-      "model_args_names": ["context", "question"]
+      "model_args_names": ["text1", "question"]
     },
     "ODQA": {
       "host": "",

--- a/utils/server_utils/server_config.json
+++ b/utils/server_utils/server_config.json
@@ -40,7 +40,7 @@
       "host": "",
       "port": "",
       "model_endpoint": "/squad",
-      "model_args_names": ["text1", "question"]
+      "model_args_names": ["text1", "text2"]
     },
     "ODQA": {
       "host": "",


### PR DESCRIPTION
Change default keyword from "context" to "text1", so raised on the cluster models and raised locally models have identical API's.