### PR TITLE
bug: fix lazy_tokenizer.LazyTokenizer import

### DIFF
--- a/examples/tutorials/04_deeppavlov_chitchat.ipynb
+++ b/examples/tutorials/04_deeppavlov_chitchat.ipynb
@@ -269,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from deeppavlov.models.preprocessors.lazy_tokenizer import LazyTokenizer\n",
+    "from deeppavlov.models.tokenizers.lazy_tokenizer import LazyTokenizer\n",
     "tokenizer = LazyTokenizer()\n",
     "tokenizer(['Hello my friend'])"
    ]
@@ -1181,7 +1181,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   },
   {
    "cell_type": "code",
@@ -1198,7 +1200,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1212,7 +1216,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -1224,7 +1230,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 3.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -1235,5 +1241,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 0
 }

--- a/examples/tutorials/04_deeppavlov_chitchat.ipynb
+++ b/examples/tutorials/04_deeppavlov_chitchat.ipynb
@@ -1181,9 +1181,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   },
   {
    "cell_type": "code",
@@ -1200,9 +1198,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1216,9 +1212,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    ""
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -1230,7 +1224,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -1241,5 +1235,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }


### PR DESCRIPTION

lazy_tokenizer was moved from deeppavlov.models.preprocessors to
deeppavlov.models.tokenizers. Change import statement accordingly