### PR TITLE
update (elmo): update elmo interface

### DIFF
--- a/deeppavlov/configs/elmo/elmo_en-1billion.json
+++ b/deeppavlov/configs/elmo/elmo_en-1billion.json
@@ -11,6 +11,7 @@
       },
       {
         "name": "elmo",
+        "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_en-1billion.json
+++ b/deeppavlov/configs/elmo/elmo_en-1billion.json
@@ -12,6 +12,7 @@
       {
         "name": "elmo",
         "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
+        "mini_batch_size": 32,
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-news.json
+++ b/deeppavlov/configs/elmo/elmo_ru-news.json
@@ -11,6 +11,7 @@
       },
       {
         "name": "elmo",
+        "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-news.json
+++ b/deeppavlov/configs/elmo/elmo_ru-news.json
@@ -12,6 +12,7 @@
       {
         "name": "elmo",
         "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
+        "mini_batch_size": 32,
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-twitter.json
+++ b/deeppavlov/configs/elmo/elmo_ru-twitter.json
@@ -11,6 +11,7 @@
       },
       {
         "name": "elmo",
+        "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-twitter.json
+++ b/deeppavlov/configs/elmo/elmo_ru-twitter.json
@@ -12,6 +12,7 @@
       {
         "name": "elmo",
         "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
+        "mini_batch_size": 32,
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-wiki.json
+++ b/deeppavlov/configs/elmo/elmo_ru-wiki.json
@@ -11,6 +11,7 @@
       },
       {
         "name": "elmo",
+        "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
         "in": [
           "tokens"
         ],

--- a/deeppavlov/configs/elmo/elmo_ru-wiki.json
+++ b/deeppavlov/configs/elmo/elmo_ru-wiki.json
@@ -12,6 +12,7 @@
       {
         "name": "elmo",
         "elmo_output_names": ["lstm_outputs1", "lstm_outputs2", "word_emb"],
+        "mini_batch_size": 32,
         "in": [
           "tokens"
         ],

--- a/deeppavlov/models/embedders/elmo_embedder.py
+++ b/deeppavlov/models/embedders/elmo_embedder.py
@@ -38,7 +38,7 @@ class ELMoEmbedder(Component):
     Parameters:
         spec: A ``ModuleSpec`` defining the Module to instantiate or a path where to load a ``ModuleSpec`` from via
             ``tenserflow_hub.load_module_spec`` by using `TensorFlow Hub <https://www.tensorflow.org/hub/overview>`__.
-        elmo_output_names: A list of output ELMo. You can use combination of ``["word_emb", "lstm_outputs1", "lstm_outputs2","elmo"]`` and you can use separately ``["default"]``. See `TensorFlow Hub <https://www.tensorflow.org/hub/overview>`__ for more information about it.
+        elmo_output_names: A list of output ELMo. You can use combination of ``["word_emb", "lstm_outputs1", "lstm_outputs2","elmo"]`` and you can use separately ``["default"]``. See `TensorFlow Hub <https://www.tensorflow.org/hub/modules/google/elmo/2>`__ for more information about it.
         dim: Dimensionality of output token embeddings of ELMo model.
         pad_zero: Whether to use pad samples or not.
         concat_last_axis: A boolean that enables/disables last axis concatenation. It is not used for ``elmo_output_names = ["default"]``.

--- a/deeppavlov/models/embedders/elmo_embedder.py
+++ b/deeppavlov/models/embedders/elmo_embedder.py
@@ -26,12 +26,13 @@ from deeppavlov.core.common.log import get_logger
 from deeppavlov.core.common.registry import register
 from deeppavlov.core.data.utils import zero_pad
 from deeppavlov.core.models.component import Component
+from deeppavlov.core.models.tf_backend import TfModelMeta
 
 log = get_logger(__name__)
 
 
 @register('elmo')
-class ELMoEmbedder(Component):
+class ELMoEmbedder(Component, metaclass=TfModelMeta):
     """
     ``ELMo`` (Embeddings from Language Models) representations are pre-trained contextual representations from
     large-scale bidirectional language models. See a paper `Deep contextualized word representations
@@ -226,3 +227,7 @@ class ELMoEmbedder(Component):
         """
 
         yield from ['<S>', '</S>', '<UNK>']
+
+
+    def destroy(self):
+        self.sess.close()

--- a/deeppavlov/models/embedders/elmo_embedder.py
+++ b/deeppavlov/models/embedders/elmo_embedder.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-from typing import Iterator, List, Union
+from typing import Iterator, List, Union, Optional
 
 
 import numpy as np
@@ -76,8 +76,8 @@ class ELMoEmbedder(Component, metaclass=TfModelMeta):
 
 
     """
-    def __init__(self, spec: str, elmo_output_names: List = None, dim: int = None, pad_zero: bool = False,
-                 concat_last_axis: bool = True, max_token: int = None, **kwargs) -> None:
+    def __init__(self, spec: str, elmo_output_names: Optional[List] = None, dim: Optional[int] = None, pad_zero: bool = False,
+                 concat_last_axis: bool = True, max_token: Optional[int] = None, **kwargs) -> None:
 
         self.spec = spec if '://' in spec else str(expand_path(spec))
 


### PR DESCRIPTION
The elmo interface has been updated.
Short list of changes:
- the parameter "elmo_output_names" was added to use a combination of ELMo outputs
- added "concat_last_axis" if you want to concatenate all ELMo representations
- the parameter "max_token" is added - this is the limit of a number of words per line in a batch
- added the "mini_batch_size" parameter is used to reduce  memory requirements of a device