### PR TITLE
Feature/clf projection layers

### DIFF
--- a/deeppavlov/models/classifiers/keras_classification_model.py
+++ b/deeppavlov/models/classifiers/keras_classification_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import numpy as np
 from keras.layers import Dense, Input, concatenate, Activation, Concatenate, Reshape
 from keras.layers.wrappers import Bidirectional
@@ -230,7 +230,7 @@ class KerasClassificationModel(KerasModel):
 
     def cnn_model(self, kernel_sizes_cnn: List[int], filters_cnn: int, dense_size: int,
                   coef_reg_cnn: float = 0., coef_reg_den: float = 0., dropout_rate: float = 0.,
-                  **kwargs) -> Model:
+                  input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled model of shallow-and-wide CNN.
 
@@ -241,19 +241,26 @@ class KerasClassificationModel(KerasModel):
             coef_reg_cnn: l2-regularization coefficient for convolutions.
             coef_reg_den: l2-regularization coefficient for dense layers.
             dropout_rate: dropout rate used after convolutions and between dense layers.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
             keras.models.Model: uncompiled instance of Keras Model
         """
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         outputs = []
         for i in range(len(kernel_sizes_cnn)):
             output_i = Conv1D(filters_cnn, kernel_size=kernel_sizes_cnn[i],
                               activation=None,
                               kernel_regularizer=l2(coef_reg_cnn),
-                              padding='same')(inp)
+                              padding='same')(output)
             output_i = BatchNormalization()(output_i)
             output_i = Activation('relu')(output_i)
             output_i = GlobalMaxPooling1D()(output_i)
@@ -274,9 +281,9 @@ class KerasClassificationModel(KerasModel):
         model = Model(inputs=inp, outputs=act_output)
         return model
 
-    def dcnn_model(self, kernel_sizes_cnn: List[int], filters_cnn: int, dense_size: int,
+    def dcnn_model(self, kernel_sizes_cnn: List[int], filters_cnn: List[int], dense_size: int,
                    coef_reg_cnn: float = 0., coef_reg_den: float = 0., dropout_rate: float = 0.,
-                   **kwargs) -> Model:
+                   input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled model of deep CNN.
 
@@ -287,14 +294,19 @@ class KerasClassificationModel(KerasModel):
             coef_reg_cnn: l2-regularization coefficient for convolutions.
             coef_reg_den: l2-regularization coefficient for dense layers.
             dropout_rate: dropout rate used after convolutions and between dense layers.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
             keras.models.Model: uncompiled instance of Keras Model
         """
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
-
         output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         for i in range(len(kernel_sizes_cnn)):
             output = Conv1D(filters_cnn[i], kernel_size=kernel_sizes_cnn[i],
@@ -321,7 +333,7 @@ class KerasClassificationModel(KerasModel):
 
     def cnn_model_max_and_aver_pool(self, kernel_sizes_cnn: List[int], filters_cnn: int, dense_size: int,
                                     coef_reg_cnn: float = 0., coef_reg_den: float = 0., dropout_rate: float = 0.,
-                                    **kwargs) -> Model:
+                                    input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled model of shallow-and-wide CNN where average pooling after convolutions is replaced with
         concatenation of average and max poolings.
@@ -333,6 +345,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_cnn: l2-regularization coefficient for convolutions. Default: ``0.0``.
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate used after convolutions and between dense layers. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -340,13 +355,17 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         outputs = []
         for i in range(len(kernel_sizes_cnn)):
             output_i = Conv1D(filters_cnn, kernel_size=kernel_sizes_cnn[i],
                               activation=None,
                               kernel_regularizer=l2(coef_reg_cnn),
-                              padding='same')(inp)
+                              padding='same')(output)
             output_i = BatchNormalization()(output_i)
             output_i = Activation('relu')(output_i)
             output_i_0 = GlobalMaxPooling1D()(output_i)
@@ -371,7 +390,8 @@ class KerasClassificationModel(KerasModel):
 
     def bilstm_model(self, units_lstm: int, dense_size: int,
                      coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
-                     dropout_rate: float = 0., rec_dropout_rate: float = 0., **kwargs) -> Model:
+                     dropout_rate: float = 0., rec_dropout_rate: float = 0.,
+                     input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled BiLSTM.
 
@@ -382,6 +402,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den (float): l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate (float): dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate (float): dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -389,12 +412,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         output = Bidirectional(LSTM(units_lstm, activation='tanh',
                                     return_sequences=True,
                                     kernel_regularizer=l2(coef_reg_lstm),
                                     dropout=dropout_rate,
-                                    recurrent_dropout=rec_dropout_rate))(inp)
+                                    recurrent_dropout=rec_dropout_rate))(output)
 
         output = GlobalMaxPooling1D()(output)
         output = Dropout(rate=dropout_rate)(output)
@@ -411,7 +438,7 @@ class KerasClassificationModel(KerasModel):
     def bilstm_bilstm_model(self, units_lstm_1: int, units_lstm_2: int, dense_size: int,
                             coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
                             dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                            **kwargs) -> Model:
+                            input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled two-layers BiLSTM.
 
@@ -423,6 +450,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -430,12 +460,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         output = Bidirectional(LSTM(units_lstm_1, activation='tanh',
                                     return_sequences=True,
                                     kernel_regularizer=l2(coef_reg_lstm),
                                     dropout=dropout_rate,
-                                    recurrent_dropout=rec_dropout_rate))(inp)
+                                    recurrent_dropout=rec_dropout_rate))(output)
 
         output = Dropout(rate=dropout_rate)(output)
 
@@ -460,7 +494,7 @@ class KerasClassificationModel(KerasModel):
     def bilstm_cnn_model(self, units_lstm: int, kernel_sizes_cnn: List[int], filters_cnn: int, dense_size: int,
                          coef_reg_lstm: float = 0., coef_reg_cnn: float = 0., coef_reg_den: float = 0.,
                          dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                         **kwargs) -> Model:
+                         input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled BiLSTM-CNN.
 
@@ -474,6 +508,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -481,12 +518,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         output = Bidirectional(LSTM(units_lstm, activation='tanh',
                                     return_sequences=True,
                                     kernel_regularizer=l2(coef_reg_lstm),
                                     dropout=dropout_rate,
-                                    recurrent_dropout=rec_dropout_rate))(inp)
+                                    recurrent_dropout=rec_dropout_rate))(output)
 
         output = Reshape(target_shape=(self.opt['text_size'], 2 * units_lstm))(output)
         outputs = []
@@ -516,7 +557,7 @@ class KerasClassificationModel(KerasModel):
     def cnn_bilstm_model(self, kernel_sizes_cnn: List[int], filters_cnn: int, units_lstm: int, dense_size: int,
                          coef_reg_cnn: float = 0., coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
                          dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                         **kwargs) -> Model:
+                         input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Build un-compiled BiLSTM-CNN.
 
@@ -530,6 +571,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -537,13 +581,17 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         outputs = []
         for i in range(len(kernel_sizes_cnn)):
             output_i = Conv1D(filters_cnn, kernel_size=kernel_sizes_cnn[i],
                               activation=None,
                               kernel_regularizer=l2(coef_reg_cnn),
-                              padding='same')(inp)
+                              padding='same')(output)
             output_i = BatchNormalization()(output_i)
             output_i = Activation('relu')(output_i)
             output_i = MaxPooling1D()(output_i)
@@ -573,7 +621,7 @@ class KerasClassificationModel(KerasModel):
     def bilstm_self_add_attention_model(self, units_lstm: int, dense_size: int, self_att_hid: int, self_att_out: int,
                                         coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
                                         dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                                        **kwargs) -> Model:
+                                        input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Method builds uncompiled model of BiLSTM with self additive attention.
 
@@ -586,6 +634,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -593,11 +644,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
+
         output = Bidirectional(LSTM(units_lstm, activation='tanh',
                                     return_sequences=True,
                                     kernel_regularizer=l2(coef_reg_lstm),
                                     dropout=dropout_rate,
-                                    recurrent_dropout=rec_dropout_rate))(inp)
+                                    recurrent_dropout=rec_dropout_rate))(output)
 
         output = MaxPooling1D(pool_size=2, strides=3)(output)
 
@@ -618,7 +674,7 @@ class KerasClassificationModel(KerasModel):
     def bilstm_self_mult_attention_model(self, units_lstm: int, dense_size: int, self_att_hid: int, self_att_out: int,
                                          coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
                                          dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                                         **kwargs) -> Model:
+                                         input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Method builds uncompiled model of BiLSTM with self multiplicative attention.
 
@@ -631,6 +687,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiLSTM and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for LSTM. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -638,12 +697,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         output = Bidirectional(LSTM(units_lstm, activation='tanh',
                                     return_sequences=True,
                                     kernel_regularizer=l2(coef_reg_lstm),
                                     dropout=dropout_rate,
-                                    recurrent_dropout=rec_dropout_rate))(inp)
+                                    recurrent_dropout=rec_dropout_rate))(output)
 
         output = MaxPooling1D(pool_size=2, strides=3)(output)
 
@@ -664,7 +727,7 @@ class KerasClassificationModel(KerasModel):
     def bigru_model(self, units_lstm: int, dense_size: int,
                     coef_reg_lstm: float = 0., coef_reg_den: float = 0.,
                     dropout_rate: float = 0., rec_dropout_rate: float = 0.,
-                    **kwargs) -> Model:
+                    input_projection_size: Optional[int] = None, **kwargs) -> Model:
         """
         Method builds uncompiled model BiGRU.
 
@@ -675,6 +738,9 @@ class KerasClassificationModel(KerasModel):
             coef_reg_den: l2-regularization coefficient for dense layers. Default: ``0.0``.
             dropout_rate: dropout rate to be used after BiGRU and between dense layers. Default: ``0.0``.
             rec_dropout_rate: dropout rate for GRU. Default: ``0.0``.
+            input_projection_size: if not None, adds Dense layer (with ``relu`` activation)
+                                   right after input layer to the size ``input_projection_size``.
+                                   Useful for input dimentionaliry recuction. Default: ``None``.
             kwargs: other non-used parameters
 
         Returns:
@@ -682,12 +748,16 @@ class KerasClassificationModel(KerasModel):
         """
 
         inp = Input(shape=(self.opt['text_size'], self.opt['embedding_size']))
+        output = inp
+
+        if input_projection_size is not None:
+            output = Dense(input_projection_size, activation='relu')(output)
 
         output = Bidirectional(GRU(units_lstm, activation='tanh',
                                    return_sequences=True,
                                    kernel_regularizer=l2(coef_reg_lstm),
                                    dropout=dropout_rate,
-                                   recurrent_dropout=rec_dropout_rate))(inp)
+                                   recurrent_dropout=rec_dropout_rate))(output)
 
         output = GlobalMaxPooling1D()(output)
         output = Dropout(rate=dropout_rate)(output)

--- a/tests/test_configs/classifiers/intents_snips_bilstm_proj_layer.json
+++ b/tests/test_configs/classifiers/intents_snips_bilstm_proj_layer.json
@@ -1,0 +1,130 @@
+{
+  "dataset_reader": {
+    "name": "basic_classification_reader",
+    "x": "text",
+    "y": "intents",
+    "data_path": "snips",
+    "url": "http://files.deeppavlov.ai/datasets/snips_intents/train.csv"
+  },
+  "dataset_iterator": {
+    "name": "basic_classification_iterator",
+    "seed": 42,
+    "field_to_split": "train",
+    "split_fields": [
+      "train",
+      "valid"
+    ],
+    "split_proportions": [
+      0.9,
+      0.1
+    ]
+  },
+  "chainer": {
+    "in": [
+      "x"
+    ],
+    "in_y": [
+      "y"
+    ],
+    "pipe": [
+      {
+        "id": "classes_vocab",
+        "name": "default_vocab",
+        "fit_on": [
+          "y"
+        ],
+        "level": "token",
+        "save_path": "vocabs/snips_classes.dict",
+        "load_path": "vocabs/snips_classes.dict"
+      },
+      {
+        "in": "x",
+        "out": "x_tok",
+        "id": "my_tokenizer",
+        "name": "nltk_tokenizer",
+        "tokenizer": "wordpunct_tokenize"
+      },
+      {
+        "in": "x_tok",
+        "out": "x_emb",
+        "id": "my_embedder",
+        "name": "fasttext",
+        "save_path": "embeddings/dstc2_fastText_model.bin",
+        "load_path": "embeddings/dstc2_fastText_model.bin",
+        "dim": 100
+      },
+      {
+        "in": [
+          "x_emb"
+        ],
+        "in_y": [
+          "y"
+        ],
+        "out": [
+          "y_labels",
+          "y_probas_dict"
+        ],
+        "main": true,
+        "name": "keras_classification_model",
+        "save_path": "classifiers/intent_cnn_snips_bistlm",
+        "load_path": "classifiers/intent_cnn_snips_bilstm",
+        "embedding_size": "#my_embedder.dim",
+        "classes": "#classes_vocab.keys()",
+        "units_lstm": 64,
+        "confident_threshold": 0.5,
+        "optimizer": "Adam",
+        "lear_rate": 0.01,
+        "lear_rate_decay": 0.1,
+        "loss": "binary_crossentropy",
+        "text_size": 15,
+        "coef_reg_lstm": 1e-4,
+        "coef_reg_den": 1e-4,
+        "dropout_rate": 0.5,
+        "rec_dropout_rate": 0.5,
+        "dense_size": 100,
+        "input_projection_size": 64,
+        "model_name": "bilstm_model"
+      }
+    ],
+    "out": [
+      "y_labels",
+      "y_probas_dict"
+    ]
+  },
+  "train": {
+    "epochs": 1,
+    "batch_size": 64,
+    "metrics": [
+      "classification_accuracy",
+      "classification_f1",
+      "classification_roc_auc"
+    ],
+    "validation_patience": 5,
+    "val_every_n_epochs": 5,
+    "log_every_n_epochs": 1,
+    "show_examples": false,
+    "validate_best": true,
+    "test_best": false
+  },
+  "metadata": {
+    "requirements": [
+      "../dp_requirements/tf.txt",
+      "../dp_requirements/fasttext.txt"
+    ],
+    "labels": {
+      "telegram_utils": "IntentModel"
+    },
+    "download": [
+      "http://files.deeppavlov.ai/deeppavlov_data/intents.tar.gz",
+      "http://files.deeppavlov.ai/deeppavlov_data/vocabs.tar.gz",
+      {
+        "url": "http://files.deeppavlov.ai/datasets/snips_intents/train.csv",
+        "subdir": "snips"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/embeddings/dstc2_fastText_model.bin",
+        "subdir": "embeddings"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added new optional parameter to all of keras_classification_model
model functions. If input_projection_size is specified,
Dense(input_projection_size, 'relu') layer is applied just after input layer.
Also created test config with this feature enabled.

Usefull for reducing dimentionality of embeddings (for example,
when using ELMO embedders).