### PR TITLE
Reduce skipped tests count by 198

### DIFF
--- a/tests/test_quick_start.py
+++ b/tests/test_quick_start.py
@@ -215,6 +215,16 @@ def download_config(conf_file):
             download_config(conf_file)
 
 
+def install_config(conf_file):
+    logfile = io.BytesIO(b'')
+    p = pexpect.popen_spawn.PopenSpawn(sys.executable + " -m deeppavlov install " + str(conf_file), timeout=None,
+                                       logfile=logfile)
+    p.readlines()
+    if p.wait() != 0:
+        raise RuntimeError('Installing process of {} returned non-zero exit code: \n{}'
+                           .format(conf_file, logfile.getvalue().decode()))
+
+
 def setup_module():
     shutil.rmtree(str(test_configs_path), ignore_errors=True)
     shutil.rmtree(str(download_path), ignore_errors=True)
@@ -241,14 +251,6 @@ def teardown_module():
 @pytest.mark.parametrize("model,conf_file,model_dir,mode", TEST_GRID, scope='class')
 class TestQuickStart(object):
     @staticmethod
-    def install(conf_file):
-        logfile = io.BytesIO(b'')
-        p = pexpect.popen_spawn.PopenSpawn(sys.executable + " -m deeppavlov install " + str(conf_file), timeout=None,
-                                           logfile=logfile)
-        p.readlines()
-        if p.wait() != 0:
-            raise RuntimeError('Installing process of {} returned non-zero exit code: \n{}'
-                               .format(conf_file, logfile.getvalue().decode()))
 
     @staticmethod
     def interact(conf_file, model_dir, qr_list=None):
@@ -314,7 +316,7 @@ class TestQuickStart(object):
     def test_interacting_pretrained_model(self, model, conf_file, model_dir, mode):
         if 'IP' in mode:
             config_file_path = str(test_configs_path.joinpath(conf_file))
-            self.install(config_file_path)
+            install_config(config_file_path)
             deep_download(['-c', config_file_path])
 
             self.interact(test_configs_path / conf_file, model_dir, PARAMS[model][(conf_file, model_dir, mode)])
@@ -337,7 +339,7 @@ class TestQuickStart(object):
 
             if 'IP' not in mode:
                 config_path = str(test_configs_path.joinpath(conf_file))
-                self.install(config_path)
+                install_config(config_path)
                 deep_download(['-c', config_path])
             shutil.rmtree(str(model_path),  ignore_errors=True)
 
@@ -359,6 +361,7 @@ def test_crossvalidation():
     model_dir = 'faq'
     conf_file = 'cv/cv_tfidf_autofaq.json'
 
+    install_config(conf_file)
     download_config(conf_file)
 
     c = test_configs_path / conf_file
@@ -387,6 +390,7 @@ def test_param_search():
     c = test_configs_path / conf_file
     model_path = download_path / model_dir
 
+    install_config(conf_file)
     deep_download(c)
 
     shutil.rmtree(str(model_path),  ignore_errors=True)
@@ -406,6 +410,7 @@ def test_evolving():
     model_dir = 'evolution'
     conf_file = 'evolution/evolve_intents_snips.json'
 
+    install_config(conf_file)
     download_config(conf_file)
 
     c = test_configs_path / conf_file

--- a/tests/test_quick_start.py
+++ b/tests/test_quick_start.py
@@ -359,12 +359,12 @@ def test_crossvalidation():
     model_dir = 'faq'
     conf_file = 'cv/cv_tfidf_autofaq.json'
 
-    install_config(conf_file)
     download_config(conf_file)
 
     c = test_configs_path / conf_file
     model_path = download_path / model_dir
 
+    install_config(c)
     deep_download(c)
     shutil.rmtree(str(model_path),  ignore_errors=True)
 
@@ -388,7 +388,7 @@ def test_param_search():
     c = test_configs_path / conf_file
     model_path = download_path / model_dir
 
-    install_config(conf_file)
+    install_config(c)
     deep_download(c)
 
     shutil.rmtree(str(model_path),  ignore_errors=True)
@@ -407,13 +407,12 @@ def test_param_search():
 def test_evolving():
     model_dir = 'evolution'
     conf_file = 'evolution/evolve_intents_snips.json'
-
-    install_config(conf_file)
     download_config(conf_file)
 
     c = test_configs_path / conf_file
     model_path = download_path / model_dir
 
+    install_config(c)
     deep_download(c)
 
     shutil.rmtree(str(model_path), ignore_errors=True)

--- a/tests/test_quick_start.py
+++ b/tests/test_quick_start.py
@@ -251,8 +251,6 @@ def teardown_module():
 @pytest.mark.parametrize("model,conf_file,model_dir,mode", TEST_GRID, scope='class')
 class TestQuickStart(object):
     @staticmethod
-
-    @staticmethod
     def interact(conf_file, model_dir, qr_list=None):
         qr_list = qr_list or []
         logfile = io.BytesIO(b'')


### PR DESCRIPTION
Move evolution, crossvalidation and paramsearch away from the `TestQuickStart` object to reduce the count of skipped tests