### PR TITLE
Added ensure_ascii mode to dialog logging feature

### DIFF
--- a/deeppavlov/core/agent/dialog_logger.py
+++ b/deeppavlov/core/agent/dialog_logger.py
@@ -51,7 +51,7 @@ class DialogLogger:
             self.agent_name: str = agent_name or self.config['agent_name']
             self.log_max_size: int = self.config['logfile_max_size_kb']
             self.log_file = self._get_log_file()
-            self.log_file.writelines('\"Agent initiated\"\n')
+            self.log_file.writelines('"Agent initiated"\n')
 
     @staticmethod
     def _get_timestamp_utc_str() -> str:

--- a/deeppavlov/core/agent/dialog_logger.py
+++ b/deeppavlov/core/agent/dialog_logger.py
@@ -51,7 +51,7 @@ class DialogLogger:
             self.agent_name: str = agent_name or self.config['agent_name']
             self.log_max_size: int = self.config['logfile_max_size_kb']
             self.log_file = self._get_log_file()
-            self.log_file.writelines('Agent initiated\n')
+            self.log_file.writelines('\"Agent initiated\"\n')
 
     @staticmethod
     def _get_timestamp_utc_str() -> str:
@@ -72,7 +72,7 @@ class DialogLogger:
         log_dir: Path = Path(self.config['log_path']).expanduser().resolve() / self.agent_name
         log_dir.mkdir(parents=True, exist_ok=True)
         log_file_path = Path(log_dir, f'{self._get_timestamp_utc_str()}_{self.agent_name}.log')
-        log_file = open(log_file_path, 'a', buffering=1)
+        log_file = open(log_file_path, 'a', buffering=1, encoding='utf8')
         return log_file
 
     def _log(self, utterance: Any, direction: str, dialog_id: Optional[Hashable]=None):
@@ -104,7 +104,7 @@ class DialogLogger:
                 log_msg['dialog_id'] = dialog_id
                 log_msg['direction'] = direction
                 log_msg['message'] = utterance
-                log_str = json.dumps(log_msg)
+                log_str = json.dumps(log_msg, ensure_ascii=self.config['ensure_ascii'])
                 self.log_file.write(f'{log_str}\n')
             except IOError:
                 log.error('Failed to write dialog log.')

--- a/docs/devguides/settings.rst
+++ b/docs/devguides/settings.rst
@@ -20,4 +20,5 @@ Following dialog logging settings are available:
 1. **enabled** (default: ``false``): turns on/off dialog logging for DeepPavlov instance;
 2. **log_path** (default: ``~/.deeppavlov/dialog_logs``): sets directory where dialog logs are stored;
 3. **agent_name** (default: ``dp_agent``): sets subdirectory name for storing dialog logs;
-4. **logfile_max_size_kb** (default: ``10240``): sets logfile maximum size in kilobytes. If exceeded, new log file is created.
+4. **logfile_max_size_kb** (default: ``10240``): sets logfile maximum size in kilobytes. If exceeded, new log file is created;
+5. **ensure_ascii** (default: ``false``): If true, converts all non-ASCII symbols in logged content to Unicode code points.

--- a/docs/devguides/settings.rst
+++ b/docs/devguides/settings.rst
@@ -21,4 +21,4 @@ Following dialog logging settings are available:
 2. **log_path** (default: ``~/.deeppavlov/dialog_logs``): sets directory where dialog logs are stored;
 3. **agent_name** (default: ``dp_agent``): sets subdirectory name for storing dialog logs;
 4. **logfile_max_size_kb** (default: ``10240``): sets logfile maximum size in kilobytes. If exceeded, new log file is created;
-5. **ensure_ascii** (default: ``false``): If true, converts all non-ASCII symbols in logged content to Unicode code points.
+5. **ensure_ascii** (default: ``false``): If ``true``, converts all non-ASCII symbols in logged content to Unicode code points.

--- a/utils/settings/.default/dialog_logger_config.json
+++ b/utils/settings/.default/dialog_logger_config.json
@@ -2,5 +2,6 @@
   "enabled": false,
   "agent_name": "dp_agent",
   "log_path": "~/.deeppavlov/dialog_logs",
-  "logfile_max_size_kb": 10240
+  "logfile_max_size_kb": 10240,
+  "ensure_ascii": false
 }

--- a/utils/settings/dialog_logger_config.json
+++ b/utils/settings/dialog_logger_config.json
@@ -1,5 +1,5 @@
 {
-  "enabled": true,
+  "enabled": false,
   "agent_name": "dp_agent",
   "log_path": "~/.deeppavlov/dialog_logs",
   "logfile_max_size_kb": 10240,

--- a/utils/settings/dialog_logger_config.json
+++ b/utils/settings/dialog_logger_config.json
@@ -1,6 +1,7 @@
 {
-  "enabled": false,
+  "enabled": true,
   "agent_name": "dp_agent",
   "log_path": "~/.deeppavlov/dialog_logs",
-  "logfile_max_size_kb": 10240
+  "logfile_max_size_kb": 10240,
+  "ensure_ascii": false
 }


### PR DESCRIPTION
Fixed dialog logging: for now non-unicode characters are written to dialog logs for default.