### PR TITLE
Ignore data_type at test if it is empty

### DIFF
--- a/deeppavlov/core/commands/train.py
+++ b/deeppavlov/core/commands/train.py
@@ -251,6 +251,10 @@ def _test_model(model: Chainer, metrics_functions: List[Metric],
 
     expected_outputs = list(set().union(model.out_params, *[m.inputs for m in metrics_functions]))
 
+    if not iterator.data[data_type]:
+        log.warning(f'Could not log examples for {data_type}, assuming it\'s empty')
+        return {'metrics': None}
+
     outputs = {out: [] for out in expected_outputs}
     examples = 0
     for x, y_true in iterator.gen_batches(batch_size, data_type, shuffle=False):

--- a/deeppavlov/core/commands/train.py
+++ b/deeppavlov/core/commands/train.py
@@ -253,7 +253,7 @@ def _test_model(model: Chainer, metrics_functions: List[Metric],
 
     if not iterator.data[data_type]:
         log.warning(f'Could not log examples for {data_type}, assuming it\'s empty')
-        return {'metrics': None}
+        return {'eval_examples_count': 0, 'metrics': None, 'time_spent': str(datetime.timedelta(seconds=0))}
 
     outputs = {out: [] for out in expected_outputs}
     examples = 0


### PR DESCRIPTION
Useful if you don't have valid/test set and dons't want your training to crash at the end.