### PR TITLE
Change PDF builder for correct handling of Russian

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,8 +3,7 @@
 build:
   image: latest
 
-formats:
-  - pdf
+formats: []
 
 python:
   pip_install: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,8 @@ htmlhelp_basename = f'{project}-Docs'
 
 # -- Options for LaTeX output ------------------------------------------------
 
+latex_engine = 'xelatex'
+
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #


### PR DESCRIPTION
With default PDF builder (pdflatex), it will be possible to easily build the docs with occasional Russian symbols only since Sphinx 2.0 release. So, changing for xelatex should work now with Sphinx <2.0, however, we need to decide, whether to provide PDF through ReadTheDocs or just make manual builds locally when it is necessary.