### PR TITLE
Fix train metrics functions

### DIFF
--- a/deeppavlov/core/commands/train.py
+++ b/deeppavlov/core/commands/train.py
@@ -380,7 +380,7 @@ def _train_batches(model: Chainer, iterator: DataLearningIterator, train_config:
     try:
         while True:
             for x, y_true in iterator.gen_batches(train_config['batch_size']):
-                if log_on:
+                if log_on and len(train_metrics_functions) > 0:
                     y_predicted = list(model.compute(list(x), list(y_true), targets=expected_outputs))
                     if len(expected_outputs) == 1:
                         y_predicted = [y_predicted]


### PR DESCRIPTION
We do not need to evaluate a model each batch when there are no train metrics to evaluate, i.e. when using empty list for "train_metrics" config: https://github.com/deepmipt/DeepPavlov/blob/99e7d890b6d366337ac97477bf3d31c048370561/deeppavlov/configs/ranking/ranking_ubuntu_v1_mt_word2vec_smn.json#L88
It can significantly speed up the training time.