### PR TITLE
Pop Ranker for ODQA

### DIFF
--- a/deeppavlov/configs/doc_retrieval/en_ranker_pop_enwiki20180211.json
+++ b/deeppavlov/configs/doc_retrieval/en_ranker_pop_enwiki20180211.json
@@ -1,0 +1,103 @@
+{
+  "dataset_reader": {
+    "class_name": "odqa_reader",
+    "data_path": "{DOWNLOADS_PATH}/odqa/enwiki",
+    "save_path": "{DOWNLOADS_PATH}/odqa/enwiki.db",
+    "dataset_format": "wiki"
+  },
+  "dataset_iterator": {
+    "class_name": "sqlite_iterator",
+    "shuffle": false,
+    "load_path": "{DOWNLOADS_PATH}/odqa/enwiki.db"
+  },
+  "chainer": {
+    "in": [
+      "docs"
+    ],
+    "in_y": [
+      "doc_ids",
+      "doc_nums"
+    ],
+    "out": [
+      "pop_doc_ids"
+    ],
+    "pipe": [
+      {
+        "class_name": "hashing_tfidf_vectorizer",
+        "id": "vectorizer",
+        "fit_on_batch": [
+          "docs",
+          "doc_ids",
+          "doc_nums"
+        ],
+        "save_path": "{MODELS_PATH}/odqa/enwiki_tfidf_matrix.npz",
+        "load_path": "{MODELS_PATH}/odqa/enwiki_tfidf_matrix.npz",
+        "tokenizer": {
+          "class_name": "stream_spacy_tokenizer",
+          "lemmas": true,
+          "ngram_range": [
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "class_name": "tfidf_ranker",
+        "top_n": 20,
+        "in": [
+          "docs"
+        ],
+        "out": [
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
+        ],
+        "vectorizer": "#vectorizer"
+      },
+       {
+        "class_name": "pop_ranker",
+        "pop_dict_path": "{DOWNLOADS_PATH}/odqa/enwiki20180211_popularities.json",
+        "load_path": "{MODELS_PATH}/odqa/logreg_3features.joblib",
+        "top_n": 10,
+        "in": ["tfidf_doc_ids", "tfidf_doc_scores"],
+        "out": ["pop_doc_ids", "pop_doc_scores"]
+      }
+    ]
+  },
+  "train": {
+    "validate_best": false,
+    "test_best": false,
+    "batch_size": 10000
+  },
+  "metadata": {
+    "variables": {
+      "ROOT_PATH": "~/.deeppavlov",
+      "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
+      "MODELS_PATH": "{ROOT_PATH}/models"
+    },
+    "requirements": [
+      "{DEEPPAVLOV_PATH}/requirements/spacy.txt",
+      "{DEEPPAVLOV_PATH}/requirements/en_core_web_sm.txt"
+    ],
+    "labels": {
+      "server_utils": "Ranker"
+    },
+    "download": [
+      {
+        "url": "http://files.deeppavlov.ai/datasets/wikipedia/enwiki.tar.gz",
+        "subdir": "{DOWNLOADS_PATH}"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/en_odqa.tar.gz",
+        "subdir": "{MODELS_PATH}"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/datasets/wikipedia/enwiki20180211_popularities.tar.gz",
+        "subdir": "{DOWNLOADS_PATH}"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/pop_ranker.tar.gz",
+        "subdir": "{MODELS_PATH}"
+      }
+    ]
+  }
+}

--- a/deeppavlov/configs/doc_retrieval/en_ranker_tfidf_enwiki20161221.json
+++ b/deeppavlov/configs/doc_retrieval/en_ranker_tfidf_enwiki20161221.json
@@ -12,17 +12,23 @@
   },
   "chainer": {
     "in": [
-      "x"
+      "docs"
+    ],
+    "in_y": [
+      "doc_ids",
+      "doc_nums"
     ],
     "out": [
-      "y"
+      "tfidf_doc_ids"
     ],
     "pipe": [
       {
         "class_name": "hashing_tfidf_vectorizer",
         "id": "vectorizer",
         "fit_on_batch": [
-          "x"
+          "docs",
+          "doc_ids",
+          "doc_nums"
         ],
         "save_path": "{MODELS_PATH}/odqa/enwiki20161221_tfidf_matrix.npz",
         "load_path": "{MODELS_PATH}/odqa/enwiki20161221_tfidf_matrix.npz",
@@ -39,11 +45,11 @@
         "class_name": "tfidf_ranker",
         "top_n": 25,
         "in": [
-          "x"
+          "docs"
         ],
         "out": [
-          "y",
-          "score"
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
         ],
         "vectorizer": "#vectorizer"
       }

--- a/deeppavlov/configs/doc_retrieval/en_ranker_tfidf_wiki.json
+++ b/deeppavlov/configs/doc_retrieval/en_ranker_tfidf_wiki.json
@@ -19,7 +19,7 @@
       "doc_nums"
     ],
     "out": [
-      "y"
+      "tfidf_doc_ids"
     ],
     "pipe": [
       {
@@ -48,8 +48,8 @@
           "docs"
         ],
         "out": [
-          "y",
-          "score"
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
         ],
         "vectorizer": "#vectorizer"
       }

--- a/deeppavlov/configs/doc_retrieval/ru_ranker_tfidf_wiki.json
+++ b/deeppavlov/configs/doc_retrieval/ru_ranker_tfidf_wiki.json
@@ -19,7 +19,7 @@
       "doc_nums"
     ],
     "out": [
-      "y"
+      "tfidf_doc_ids"
     ],
     "pipe": [
       {
@@ -48,8 +48,8 @@
           "docs"
         ],
         "out": [
-          "y",
-          "score"
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
         ],
         "vectorizer": "#vectorizer"
       }

--- a/deeppavlov/configs/doc_retrieval/ru_ranker_tfidf_wiki.json
+++ b/deeppavlov/configs/doc_retrieval/ru_ranker_tfidf_wiki.json
@@ -43,7 +43,7 @@
       },
       {
         "class_name": "tfidf_ranker",
-        "top_n": 5,
+        "top_n": 25,
         "in": [
           "docs"
         ],

--- a/deeppavlov/configs/odqa/en_odqa_infer_enwiki20161221.json
+++ b/deeppavlov/configs/odqa/en_odqa_infer_enwiki20161221.json
@@ -13,16 +13,16 @@
           "question_raw"
         ],
         "out": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ]
       },
       {
         "class_name": "wiki_sqlite_vocab",
         "in": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ],
         "out": [
-          "context_raw"
+          "tfidf_doc_text"
         ],
         "join_docs": false,
         "shuffle": false,
@@ -30,8 +30,9 @@
       },
       {
         "class_name": "document_chunker",
-        "in": ["context_raw"],
+        "in": ["tfidf_doc_text"],
         "out": ["chunks"],
+        "tokens_limit": 4000,
         "flatten_result": true
       },
       {
@@ -41,6 +42,7 @@
       },
       {
         "class_name": "logit_ranker",
+        "batch_size": 10,
         "squad_model": {"config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"},
         "sort_noans": true,
         "in": [

--- a/deeppavlov/configs/odqa/en_odqa_infer_enwiki20161221.json
+++ b/deeppavlov/configs/odqa/en_odqa_infer_enwiki20161221.json
@@ -32,8 +32,8 @@
         "class_name": "document_chunker",
         "in": ["tfidf_doc_text"],
         "out": ["chunks"],
-        "tokens_limit": 4000,
-        "flatten_result": true
+        "flatten_result": true,
+        "paragraphs": true
       },
       {
         "class_name": "string_multiplier",

--- a/deeppavlov/configs/odqa/en_odqa_infer_wiki.json
+++ b/deeppavlov/configs/odqa/en_odqa_infer_wiki.json
@@ -13,16 +13,16 @@
           "question_raw"
         ],
         "out": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ]
       },
       {
         "class_name": "wiki_sqlite_vocab",
         "in": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ],
         "out": [
-          "context_raw"
+          "tfidf_doc_text"
         ],
         "join_docs": false,
         "shuffle": false,
@@ -30,8 +30,9 @@
       },
       {
         "class_name": "document_chunker",
-        "in": ["context_raw"],
+        "in": ["tfidf_doc_text"],
         "out": ["chunks"],
+        "tokens_limit": 4000,
         "flatten_result": true
       },
       {
@@ -41,6 +42,7 @@
       },
       {
         "class_name": "logit_ranker",
+        "batch_size": 10,
         "squad_model": {"config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"},
         "sort_noans": true,
         "in": [

--- a/deeppavlov/configs/odqa/en_odqa_infer_wiki.json
+++ b/deeppavlov/configs/odqa/en_odqa_infer_wiki.json
@@ -32,8 +32,8 @@
         "class_name": "document_chunker",
         "in": ["tfidf_doc_text"],
         "out": ["chunks"],
-        "tokens_limit": 4000,
-        "flatten_result": true
+        "flatten_result": true,
+        "paragraphs": true
       },
       {
         "class_name": "string_multiplier",

--- a/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
+++ b/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
@@ -1,7 +1,7 @@
 {
   "chainer": {
     "in": [
-      "docs"
+      "question_raw"
     ],
     "out": [
       "best_answer"
@@ -10,7 +10,7 @@
       {
         "config_path": "{CONFIGS_PATH}/doc_retrieval/en_ranker_pop_enwiki20180211.json",
         "in": [
-          "docs"
+          "question_raw"
         ],
         "out": [
           "pop_doc_ids"
@@ -24,9 +24,8 @@
         "out": [
           "pop_doc_text"
         ],
-        "data_dir": "odqa",
-        "shuffle": false,
         "join_docs": false,
+        "shuffle": false,
         "load_path": "{DOWNLOADS_PATH}/odqa/enwiki.db"
       },
       {
@@ -39,7 +38,7 @@
       {
         "class_name": "string_multiplier",
         "in": [
-          "docs",
+          "question_raw",
           "chunks"
         ],
         "out": [

--- a/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
+++ b/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
@@ -1,0 +1,89 @@
+{
+  "chainer": {
+    "in": [
+      "docs"
+    ],
+    "out": [
+      "best_answer"
+    ],
+    "pipe": [
+      {
+        "config_path": "{CONFIGS_PATH}/doc_retrieval/en_ranker_pop_wiki.json",
+        "in": [
+          "docs"
+        ],
+        "out": [
+          "pop_doc_ids"
+        ]
+      },
+      {
+        "class_name": "wiki_sqlite_vocab",
+        "in": [
+          "pop_doc_ids"
+        ],
+        "out": [
+          "pop_doc_text"
+        ],
+        "data_dir": "odqa",
+        "shuffle": false,
+        "join_docs": false,
+        "load_path": "{DOWNLOADS_PATH}/odqa/enwiki.db"
+      },
+      {
+        "class_name": "document_chunker",
+        "in": ["pop_doc_text"],
+        "out": ["chunks"],
+        "tokens_limit": 4000,
+        "flatten_result": true
+      },
+      {
+        "class_name": "string_multiplier",
+        "in": [
+          "docs",
+          "chunks"
+        ],
+        "out": [
+          "questions"
+        ]
+      },
+      {
+        "class_name": "logit_ranker",
+        "batch_size": 10,
+        "squad_model": {
+          "config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"
+        },
+        "sort_noans": true,
+        "in": [
+          "chunks",
+          "questions"
+        ],
+        "out": [
+          "best_answer"
+        ]
+      }
+    ]
+  },
+  "train": {
+    "validate_best": false,
+    "test_best": false,
+    "batch_size": 10000
+  },
+  "metadata": {
+    "variables": {
+      "ROOT_PATH": "~/.deeppavlov",
+      "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
+      "MODELS_PATH": "{ROOT_PATH}/models",
+      "CONFIGS_PATH": "{DEEPPAVLOV_PATH}/configs"
+    },
+  "requirements": [
+      "{DEEPPAVLOV_PATH}/requirements/tf.txt",
+      "{DEEPPAVLOV_PATH}/requirements/spacy.txt",
+      "{DEEPPAVLOV_PATH}/requirements/en_core_web_sm.txt"
+    ],
+    "labels": {
+      "server_utils": "ODQA"
+    },
+    "download": [
+    ]
+  }
+}

--- a/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
+++ b/deeppavlov/configs/odqa/en_odqa_pop_infer_enwiki20180211.json
@@ -8,7 +8,7 @@
     ],
     "pipe": [
       {
-        "config_path": "{CONFIGS_PATH}/doc_retrieval/en_ranker_pop_wiki.json",
+        "config_path": "{CONFIGS_PATH}/doc_retrieval/en_ranker_pop_enwiki20180211.json",
         "in": [
           "docs"
         ],

--- a/deeppavlov/configs/odqa/ru_odqa_infer_wiki.json
+++ b/deeppavlov/configs/odqa/ru_odqa_infer_wiki.json
@@ -13,16 +13,16 @@
           "question_raw"
         ],
         "out": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ]
       },
       {
         "class_name": "wiki_sqlite_vocab",
         "in": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ],
         "out": [
-          "context_raw"
+          "tfidf_doc_text"
         ],
         "join_docs": false,
         "shuffle": false,
@@ -30,8 +30,9 @@
       },
       {
         "class_name": "document_chunker",
-        "in": ["context_raw"],
+        "in": ["tfidf_doc_text"],
         "out": ["chunks"],
+        "tokens_limit": 4000,
         "flatten_result": true
       },
       {
@@ -41,9 +42,9 @@
       },
       {
         "class_name": "logit_ranker",
-        "squad_model": {
-          "config_path": "{CONFIGS_PATH}/squad/squad_ru.json"
-        },
+        "batch_size": 10,
+        "squad_model": {"config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"},
+        "sort_noans": true,
         "in": [
           "chunks",
           "questions"

--- a/deeppavlov/configs/odqa/ru_odqa_infer_wiki.json
+++ b/deeppavlov/configs/odqa/ru_odqa_infer_wiki.json
@@ -32,8 +32,8 @@
         "class_name": "document_chunker",
         "in": ["tfidf_doc_text"],
         "out": ["chunks"],
-        "tokens_limit": 4000,
-        "flatten_result": true
+        "flatten_result": true,
+        "paragraphs": true
       },
       {
         "class_name": "string_multiplier",

--- a/deeppavlov/core/common/registry.json
+++ b/deeppavlov/core/common/registry.json
@@ -70,6 +70,7 @@
   "params_search": "deeppavlov.core.common.params_search:ParamsSearch",
   "paraphraser_pretrain_reader": "deeppavlov.dataset_readers.paraphraser_pretrain_reader:ParaphraserPretrainReader",
   "paraphraser_reader": "deeppavlov.dataset_readers.paraphraser_reader:ParaphraserReader",
+  "pop_ranker": "deeppavlov.models.doc_retrieval.pop_ranker:PopRanker",
   "proba2labels": "deeppavlov.models.classifiers.proba2labels:Proba2Labels",
   "pymorphy_russian_lemmatizer": "deeppavlov.models.preprocessors.russian_lemmatizer:PymorphyRussianLemmatizer",
   "pymorphy_vectorizer": "deeppavlov.models.vectorizers.word_vectorizer:PymorphyVectorizer",

--- a/deeppavlov/models/doc_retrieval/pop_ranker.py
+++ b/deeppavlov/models/doc_retrieval/pop_ranker.py
@@ -29,10 +29,9 @@ class PopRanker(Component):
     """Rank documents according their tfidf scores and popularities. It is not a standalone ranker, it should be used
     for re-ranking the results of TF-IDF Ranker.
     Based on a Logistic Regression trained on 3 features:
-         - tfidf score of the article
-         - popularity of the article obtained via Wikimedia REST API as a mean number of views for the period
-           since 2017/11/05 to 2018/11/05
-         - multiplication of the two features above
+    * tfidf score of the article
+    * popularity of the article obtained via Wikimedia REST API as a mean number of views for the period since 2017/11/05 to 2018/11/05
+    * multiplication of the two features above
 
     Args:
         pop_dict_path: a path to json file with article title to article popularity map

--- a/deeppavlov/models/doc_retrieval/pop_ranker.py
+++ b/deeppavlov/models/doc_retrieval/pop_ranker.py
@@ -28,8 +28,10 @@ logger = get_logger(__name__)
 
 class PopRanker(Component):
     """Rank documents according to their tfidf scores and popularities. It is not a standalone ranker,
-     it should be used for re-ranking the results of TF-IDF Ranker.
+    it should be used for re-ranking the results of TF-IDF Ranker.
+
     Based on a Logistic Regression trained on 3 features:
+
     * tfidf score of the article
     * popularity of the article obtained via Wikimedia REST API as a mean number of views for the period since 2017/11/05 to 2018/11/05
     * multiplication of the two features above
@@ -63,7 +65,7 @@ class PopRanker(Component):
         self.active = active
 
     def __call__(self, input_doc_ids: List[List[Any]], input_doc_scores: List[List[float]]) -> \
-    Tuple[List[List], List[List]]:
+            Tuple[List[List], List[List]]:
         """Get tfidf scores and tfidf ids, re-rank them by applying logistic regression classifier,
         output pop ranker ids and pop ranker scores.
 

--- a/deeppavlov/models/doc_retrieval/pop_ranker.py
+++ b/deeppavlov/models/doc_retrieval/pop_ranker.py
@@ -1,0 +1,95 @@
+# Copyright 2017 Neural Networks and Deep Learning lab, MIPT
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Any
+from operator import itemgetter
+
+from sklearn.externals import joblib
+
+from deeppavlov.core.common.log import get_logger
+from deeppavlov.core.models.estimator import Component
+from deeppavlov.core.commands.utils import expand_path
+from deeppavlov.core.common.file import read_json
+
+logger = get_logger(__name__)
+
+
+class PopRanker(Component):
+    """Rank documents according their tfidf scores and popularities. It is not a standalone ranker, it should be used
+    for re-ranking the results of TF-IDF Ranker.
+    Based on a Logistic Regression trained on 3 features:
+         - tfidf score of the article
+         - popularity of the article obtained via Wikimedia REST API as a mean number of views for the period
+           since 2017/11/05 to 2018/11/05
+         - multiplication of the two features above
+
+    Args:
+        pop_dict_path: a path to json file with article title to article popularity map
+        load_path: a path to saved logistic regression classifier
+        top_n: a number of doc ids to return
+        active: whether to return a number specified by :attr:`top_n` (``True``) or all ids
+         (``False``)
+
+    Attributes:
+        pop_dict: a map of article titles to their popularity
+        clf: a loaded logistic regression classifier
+        top_n: a number of doc ids to return
+        active: whether to return a number specified by :attr:`top_n` or all ids
+
+    """
+
+    def __init__(self, pop_dict_path: str, load_path: str, top_n: int = 3, active: bool = True, **kwargs):
+        pop_dict_path = expand_path(pop_dict_path)
+        logger.info(f"Reading popularity dictionary from {pop_dict_path}")
+        self.pop_dict = read_json(pop_dict_path)
+        load_path = expand_path(load_path)
+        logger.info(f"Loading popularity ranker from {load_path}")
+        self.clf = joblib.load(load_path)
+        self.top_n = top_n
+        self.active = active
+
+    def __call__(self, input_doc_ids: List[List[Any]], input_doc_scores: List[List[float]]):
+        """Get tfidf scores and tfidf ids, re-rank them by applying logistic regression classifier,
+        output pop ranker ids and pop ranker scores.
+
+         Args:
+            input_doc_ids: top input doc ids of tfidf ranker
+            input_doc_scores: top input doc scores of tfidf ranker corresponding to doc ids
+
+        Returns:
+            top doc ids of pop ranker and their corresponding scores
+
+        """
+        batch_ids = []
+        batch_scores = []
+        for instance_ids, instance_scores in zip(input_doc_ids, input_doc_scores):
+            instance_probas = []
+            for idx, score in zip(instance_ids, instance_scores):
+                pop = self.pop_dict[idx]
+                features = [score, pop, score * pop]
+                prob = self.clf.predict_proba([features])
+                instance_probas.append(prob[0][1])
+
+            sort = sorted(enumerate(instance_probas), key=itemgetter(1), reverse=True)
+            sorted_probas = [item[1] for item in sort]
+            sorted_ids = [instance_ids[item[0]] for item in sort]
+
+            if self.active:
+                sorted_ids = sorted_ids[:self.top_n]
+                sorted_probas = sorted_probas[:self.top_n]
+
+            batch_ids.append(sorted_ids)
+            batch_scores.append(sorted_probas)
+
+        return batch_ids, batch_scores

--- a/deeppavlov/models/doc_retrieval/pop_ranker.py
+++ b/deeppavlov/models/doc_retrieval/pop_ranker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Any
+from typing import List, Any, Tuple
 from operator import itemgetter
 
 import numpy as np
@@ -27,8 +27,8 @@ logger = get_logger(__name__)
 
 
 class PopRanker(Component):
-    """Rank documents according their tfidf scores and popularities. It is not a standalone ranker, it should be used
-    for re-ranking the results of TF-IDF Ranker.
+    """Rank documents according to their tfidf scores and popularities. It is not a standalone ranker,
+     it should be used for re-ranking the results of TF-IDF Ranker.
     Based on a Logistic Regression trained on 3 features:
     * tfidf score of the article
     * popularity of the article obtained via Wikimedia REST API as a mean number of views for the period since 2017/11/05 to 2018/11/05
@@ -50,7 +50,8 @@ class PopRanker(Component):
 
     """
 
-    def __init__(self, pop_dict_path: str, load_path: str, top_n: int = 3, active: bool = True, **kwargs):
+    def __init__(self, pop_dict_path: str, load_path: str, top_n: int = 3, active: bool = True,
+                 **kwargs) -> None:
         pop_dict_path = expand_path(pop_dict_path)
         logger.info(f"Reading popularity dictionary from {pop_dict_path}")
         self.pop_dict = read_json(pop_dict_path)
@@ -61,7 +62,8 @@ class PopRanker(Component):
         self.top_n = top_n
         self.active = active
 
-    def __call__(self, input_doc_ids: List[List[Any]], input_doc_scores: List[List[float]]):
+    def __call__(self, input_doc_ids: List[List[Any]], input_doc_scores: List[List[float]]) -> \
+    Tuple[List[List], List[List]]:
         """Get tfidf scores and tfidf ids, re-rank them by applying logistic regression classifier,
         output pop ranker ids and pop ranker scores.
 

--- a/deeppavlov/models/preprocessors/odqa_preprocessors.py
+++ b/deeppavlov/models/preprocessors/odqa_preprocessors.py
@@ -33,30 +33,32 @@ class DocumentChunker(Component):
         keep_sentences: whether to tear up sentences between chunks or not
         tokens_limit: a number of tokens in a single chunk (usually this number corresponds to the squad model limit)
         flatten_result: whether to flatten the resulting list of lists of chunks
+        paragraphs: whether to split document by paragrahs; if set to True, tokens_limit is ignored
 
     Attributes:
         keep_sentences: whether to tear up sentences between chunks or not
         tokens_limit: a number of tokens in a single chunk
         flatten_result: whether to flatten the resulting list of lists of chunks
+        paragraphs: whether to split document by paragrahs; if set to True, tokens_limit is ignored
 
     """
 
     def __init__(self, sentencize_fn: Callable = sent_tokenize, keep_sentences: bool = True,
-                 tokens_limit: int = 400, flatten_result: bool = False, *args, **kwargs):
+                 tokens_limit: int = 400, flatten_result: bool = False,
+                 paragraphs: bool = False, *args, **kwargs):
         self._sentencize_fn = sentencize_fn
         self.keep_sentences = keep_sentences
         self.tokens_limit = tokens_limit
         self.flatten_result = flatten_result
+        self.paragraphs = paragraphs
 
-    def __call__(self, batch_docs: List[Union[str, List[str]]]) -> List[Union[List[str], List[List[str]]]]:
+    def __call__(self, batch_docs: List[Union[str, List[str]]]) -> List[
+        Union[List[str], List[List[str]]]]:
         """ Make chunks from a batch of documents. There can be several documents in each batch.
-
         Args:
             batch_docs: a batch of documents / a batch of lists of documents
-
         Returns:
             chunks of docs, flattened or not
-
         """
 
         result = []
@@ -66,27 +68,33 @@ class DocumentChunker(Component):
             if isinstance(docs, str):
                 docs = [docs]
             for doc in docs:
-                doc_chunks = []
-                if self.keep_sentences:
-                    sentences = sent_tokenize(doc)
-                    n_tokens = 0
-                    keep = []
-                    for s in sentences:
-                        n_tokens += len(s.split())
-                        if n_tokens > self.tokens_limit:
-                            if keep:
-                                doc_chunks.append(' '.join(keep))
-                                n_tokens = 0
-                                keep.clear()
-                        keep.append(s)
-                    if keep:
-                        doc_chunks.append(' '.join(keep))
-                    batch_chunks.append(doc_chunks)
+                if self.paragraphs:
+                    split_doc = doc.split('\n\n')
+                    split_doc = [sd.strip() for sd in split_doc]
+                    split_doc = list(filter(lambda x: len(x) > 40, split_doc))
+                    batch_chunks.append(split_doc)
                 else:
-                    split_doc = doc.split()
-                    doc_chunks = [split_doc[i:i + self.tokens_limit] for i in
-                                  range(0, len(split_doc), self.tokens_limit)]
-                    batch_chunks.append(doc_chunks)
+                    doc_chunks = []
+                    if self.keep_sentences:
+                        sentences = sent_tokenize(doc)
+                        n_tokens = 0
+                        keep = []
+                        for s in sentences:
+                            n_tokens += len(s.split())
+                            if n_tokens > self.tokens_limit:
+                                if keep:
+                                    doc_chunks.append(' '.join(keep))
+                                    n_tokens = 0
+                                    keep.clear()
+                            keep.append(s)
+                        if keep:
+                            doc_chunks.append(' '.join(keep))
+                        batch_chunks.append(doc_chunks)
+                    else:
+                        split_doc = doc.split()
+                        doc_chunks = [split_doc[i:i + self.tokens_limit] for i in
+                                      range(0, len(split_doc), self.tokens_limit)]
+                        batch_chunks.append(doc_chunks)
             result.append(batch_chunks)
 
         if self.flatten_result:

--- a/deeppavlov/models/preprocessors/odqa_preprocessors.py
+++ b/deeppavlov/models/preprocessors/odqa_preprocessors.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 
 @register('document_chunker')
 class DocumentChunker(Component):
-    """ Make chunks from a document or a list of documents. Don't tear up sentences if needed.
+    """Make chunks from a document or a list of documents. Don't tear up sentences if needed.
 
     Args:
         sentencize_fn: a function for sentence segmentation
@@ -45,7 +45,7 @@ class DocumentChunker(Component):
 
     def __init__(self, sentencize_fn: Callable = sent_tokenize, keep_sentences: bool = True,
                  tokens_limit: int = 400, flatten_result: bool = False,
-                 paragraphs: bool = False, *args, **kwargs):
+                 paragraphs: bool = False, *args, **kwargs) -> None:
         self._sentencize_fn = sentencize_fn
         self.keep_sentences = keep_sentences
         self.tokens_limit = tokens_limit
@@ -54,7 +54,7 @@ class DocumentChunker(Component):
 
     def __call__(self, batch_docs: List[Union[str, List[str]]]) -> List[
         Union[List[str], List[List[str]]]]:
-        """ Make chunks from a batch of documents. There can be several documents in each batch.
+        """Make chunks from a batch of documents. There can be several documents in each batch.
         Args:
             batch_docs: a batch of documents / a batch of lists of documents
         Returns:
@@ -129,6 +129,6 @@ class StringMultiplier(Component):
         """
         res = []
         for s, r in zip(batch_s, ref):
-            res.append([s]*len(r))
+            res.append([s] * len(r))
 
         return res

--- a/deeppavlov/models/preprocessors/odqa_preprocessors.py
+++ b/deeppavlov/models/preprocessors/odqa_preprocessors.py
@@ -52,8 +52,8 @@ class DocumentChunker(Component):
         self.flatten_result = flatten_result
         self.paragraphs = paragraphs
 
-    def __call__(self, batch_docs: List[Union[str, List[str]]]) -> List[
-        Union[List[str], List[List[str]]]]:
+    def __call__(self, batch_docs: List[Union[str, List[str]]]) -> \
+            List[Union[List[str], List[List[str]]]]:
         """Make chunks from a batch of documents. There can be several documents in each batch.
         Args:
             batch_docs: a batch of documents / a batch of lists of documents

--- a/docs/apiref/models/doc_retrieval.rst
+++ b/docs/apiref/models/doc_retrieval.rst
@@ -1,7 +1,7 @@
 deeppavlov.models.doc_retrieval
 ===============================
 
-Ranking classes.
+Document retrieval classes.
 
 .. automodule:: deeppavlov.models.doc_retrieval
 
@@ -11,6 +11,11 @@ Ranking classes.
     .. automethod:: __call__
 
 .. autoclass:: deeppavlov.models.doc_retrieval.logit_ranker.LogitRanker
+    :members:
+
+    .. automethod:: __call__
+
+.. autoclass:: deeppavlov.models.doc_retrieval.pop_ranker.PopRanker
     :members:
 
     .. automethod:: __call__

--- a/docs/components/popularity_ranking.rst
+++ b/docs/components/popularity_ranking.rst
@@ -2,7 +2,7 @@
 Popularity Ranker
 =================
 
-Popularity Ranker re-ranks results obtained via :doc:`my document <../tfidf_ranking>` using information about
+Popularity Ranker re-ranks results obtained via :doc:`TF-IDF Ranker <tfidf_ranking>` using information about
 the number of article views. The number of Wikipedia articles views is an open piece of information which can be
 obtained via `Wikimedia REST API <https://wikimedia.org/api/rest_v1/>`_.
 We assigned a mean number of views for the period since 2017/11/05 to 2018/11/05 to each article in our

--- a/docs/components/popularity_ranking.rst
+++ b/docs/components/popularity_ranking.rst
@@ -79,8 +79,8 @@ Run the following to interact with the ranker:
 Available Data and Pretrained Models
 ====================================
 
-Available information about Wikipedia articles popularity is downloaded to ``deeppavlov/downloads/odqa/popularities.json``
-and pre-trained logistic regression classifier is downloaded to ``deeppavlov/models/odqa/logreg_3features.joblib`` by default.
+Available information about Wikipedia articles popularity is downloaded to ``~/.deeppavlov/downloads/odqa/popularities.json``
+and pre-trained logistic regression classifier is downloaded to ``~/.deeppavlov/models/odqa/logreg_3features.joblib`` by default.
 
 
 References

--- a/docs/components/popularity_ranking.rst
+++ b/docs/components/popularity_ranking.rst
@@ -1,0 +1,91 @@
+=================
+Popularity Ranker
+=================
+
+Popularity Ranker re-ranks results obtained via :doc:`my document <../tfidf_ranking>` using information about
+the number of article views. The number of Wikipedia articles views is an open piece of information which can be
+obtained via `Wikimedia REST API <https://wikimedia.org/api/rest_v1/>`_.
+We assigned a mean number of views for the period since 2017/11/05 to 2018/11/05 to each article in our
+English Wikipedia database `enwiki20180211 <http://files.deeppavlov.ai/datasets/wikipedia/enwiki.tar.gz>`_.
+
+The inner algorithm of Popularity Ranker is a Logistic Regression classifier based on 3 features:
+
+- tfidf score of the article
+- popularity of the article
+- multiplication of two above features
+
+The classifier is trained on `SQuAD-v1.1`_ train set.
+
+Quick Start
+===========
+
+Before using the model make sure that all required packages are installed running the command:
+
+.. code:: bash
+
+    python -m deeppavlov install en_ranker_pop_enwiki20180211.json
+
+Building the model
+
+.. code:: python
+
+    from deeppavlov import configs
+    from deeppavlov.core.commands.infer import build_model
+
+    ranker = build_model(configs.doc_retrieval.en_ranker_pop_enwiki20180211, load_trained=True)
+
+Inference
+
+.. code:: python
+
+    result = ranker(['Who is Ivan Pavlov?'])
+    print(result[:5])
+
+Output
+
+::
+
+    >> ['Ivan Pavlov', 'Vladimir Bekhterev', 'Classical conditioning', 'Valentin Pavlov', 'Psychology']
+
+Text for the output titles can be further extracted with :class:`~deeppavlov.vocabs.wiki_sqlite.WikiSQLiteVocab` class.
+
+
+Configuration
+=============
+
+Default ranker config is
+:config:`doc_retrieval/en_ranker_pop_enwiki20180211.json <doc_retrieval/en_ranker_pop_enwiki20180211.json>`
+
+Running the Ranker
+==================
+
+.. note::
+
+    About **17 GB of RAM** required.
+
+Interacting
+-----------
+
+When interacting, the ranker returns document titles of the relevant
+documents.
+
+Run the following to interact with the ranker:
+
+.. code:: bash
+
+    python -m deeppavlov interact en_ranker_pop_enwiki20180211 -d
+
+
+Available Data and Pretrained Models
+====================================
+
+Available information about Wikipedia articles popularity is downloaded to ``deeppavlov/downloads/odqa/popularities.json``
+and pre-trained logistic regression classifier is downloaded to ``deeppavlov/models/odqa/logreg_3features.joblib`` by default.
+
+
+References
+==========
+
+.. target-notes::
+
+.. _`SQuAD-v1.1`: https://arxiv.org/abs/1606.05250

--- a/docs/components/tfidf_ranking.rst
+++ b/docs/components/tfidf_ranking.rst
@@ -4,7 +4,7 @@ TF-IDF Ranker
 
 This is an implementation of a document ranker based on tf-idf vectorization.
 The ranker implementation is based on `DrQA`_ project.
-The default ranker implementation takes a batch of queries as input and returns 5 document titles sorted via relevance.
+The default ranker implementation takes a batch of queries as input and returns 25 document titles sorted via relevance.
 
 Quick Start
 ===========
@@ -36,7 +36,7 @@ Inference
 .. code:: python
 
     result = ranker(['Who is Ivan Pavlov?'])
-    print(result)
+    print(result[:5])
 
 Output
 
@@ -80,6 +80,8 @@ Run the following to fit the ranker on **Russian** Wikipedia:
 
     python -m deeppavlov train ru_ranker_tfidf_wiki
 
+As a result of ranker training, a SQLite database and tf-idf matrix are created.
+
 Interacting
 -----------
 
@@ -98,13 +100,11 @@ Run the following to interact with the **Russian** ranker:
 
     python -m deeppavlov ru_ranker_tfidf_wiki -d
 
-As a result of ranker training, a SQLite database and tf-idf matrix are created.
-
 Available Data and Pretrained Models
 ====================================
 
-Wikipedia DB and pretrained tfidf matrices are downloaded in
-``deeppavlov/download/odqa`` folder by default.
+Wikipedia DB is downloaded to ``deeppavlov/downloads/odqa`` folder and pre-trained tfidf matrices are downloaded
+to ``deeppavlov/models/odqa`` folder by default.
 
 enwiki.db
 ---------

--- a/docs/components/tfidf_ranking.rst
+++ b/docs/components/tfidf_ranking.rst
@@ -103,8 +103,8 @@ Run the following to interact with the **Russian** ranker:
 Available Data and Pretrained Models
 ====================================
 
-Wikipedia DB is downloaded to ``deeppavlov/downloads/odqa`` folder and pre-trained tfidf matrices are downloaded
-to ``deeppavlov/models/odqa`` folder by default.
+Wikipedia DB is downloaded to ``~/.deeppavlov/downloads/odqa`` and pre-trained tfidf matrices are downloaded
+to ``~/.deeppavlov/models/odqa`` folder by default.
 
 enwiki.db
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,6 +29,7 @@ Welcome to DeepPavlov's documentation!
    Slot filling <components/slot_filling>
    Spelling Correction <components/spelling_correction>
    TF-IDF Ranking <components/tfidf_ranking>
+   Popularity Ranking <components/popularity_ranking>
 
 
 .. toctree::

--- a/docs/skills/odqa.rst
+++ b/docs/skills/odqa.rst
@@ -8,10 +8,14 @@ Task definition
 **Open Domain Question Answering (ODQA)** is a task to find an exact answer
 to any question in **Wikipedia** articles. Thus, given only a question, the system outputs
 the best answer it can find.
-The default ODQA implementation takes a batch of queries as input and returns 5 answers sorted via their score.
+The default ODQA implementation takes a batch of queries as input and returns the best answer.
 
 Quick Start
 ===========
+
+The example below is given for basic ODQA config :config:`en_odqa_infer_wiki <odqa/en_odqa_infer_wiki.json>`.
+Check what :ref:`other ODQA configs <odqa_configuration>` are available and simply replace `en_odqa_infer_wiki`
+with the config name of your preference.
 
 Before using the model make sure that all required packages are installed running the command:
 
@@ -102,9 +106,36 @@ Run the following to interact with **Russian ODQA**:
 Configuration
 =============
 
+.. _odqa_configuration:
+
 The **ODQA** configs suit only model inferring purposes. For training purposes use
 the :ref:`ranker configs <ranker_training>` and the :ref:`reader configs <reader_training>`
 accordingly.
+
+There are several ODQA configs available:
+
++----------------------------------------------------------------------------------------+-------------------------------------------------+
+|                                                                                        |                                                 |
+|                                                                                        |                                                 |
+| Config                                                                                 | Description                                     |
++----------------------------------------------------------------------------------------+-------------------------------------------------+
+|:config:`en_odqa_infer_wiki <odqa/en_odqa_infer_wiki.json>`                             | Basic config for **English** language. Consists |
+|                                                                                        | of TF-IDF ranker and reader. Searches for an    |
+|                                                                                        | answer in `enwiki20180211` Wikipedia dump.      |
++----------------------------------------------------------------------------------------+-------------------------------------------------+
+|:config:`en_odqa_infer_enwiki20161221 <odqa/en_odqa_infer_enwiki20161221.json>`         | Basic config for **English** language. Consists |
+|                                                                                        | of TF-IDF ranker and reader. Searches for an    |
+|                                                                                        | answer in `enwiki20161221` Wikipedia dump.      |
++----------------------------------------------------------------------------------------+-------------------------------------------------+
+|:config:`ru_odqa_infer_wiki <odqa/ru_odqa_infer_wiki.json>`                             | Basic config for **Russian** language. Consists |
+|                                                                                        | of TF-IDF ranker and reader. Searches for an    |
+|                                                                                        | answer in `ruwiki20180401` Wikipedia dump.      |
++----------------------------------------------------------------------------------------+-------------------------------------------------+
+|:config:`en_odqa_pop_infer_enwiki20180211 <odqa/en_odqa_pop_infer_enwiki20180211.json>` | Extended config for **English** language.       |
+|                                                                                        | Consists of TF-IDF Ranker, Popularity Ranker    |
+|                                                                                        | and reader. Searches for an answer in           |
+|                                                                                        | `enwiki20180211` Wikipedia dump.                |
++----------------------------------------------------------------------------------------+-------------------------------------------------+
 
 Comparison
 ==========

--- a/docs/skills/odqa.rst
+++ b/docs/skills/odqa.rst
@@ -121,20 +121,20 @@ There are several ODQA configs available:
 +----------------------------------------------------------------------------------------+-------------------------------------------------+
 |:config:`en_odqa_infer_wiki <odqa/en_odqa_infer_wiki.json>`                             | Basic config for **English** language. Consists |
 |                                                                                        | of TF-IDF ranker and reader. Searches for an    |
-|                                                                                        | answer in `enwiki20180211` Wikipedia dump.      |
+|                                                                                        | answer in ``enwiki20180211`` Wikipedia dump.    |
 +----------------------------------------------------------------------------------------+-------------------------------------------------+
 |:config:`en_odqa_infer_enwiki20161221 <odqa/en_odqa_infer_enwiki20161221.json>`         | Basic config for **English** language. Consists |
 |                                                                                        | of TF-IDF ranker and reader. Searches for an    |
-|                                                                                        | answer in `enwiki20161221` Wikipedia dump.      |
+|                                                                                        | answer in ``enwiki20161221`` Wikipedia dump.    |
 +----------------------------------------------------------------------------------------+-------------------------------------------------+
 |:config:`ru_odqa_infer_wiki <odqa/ru_odqa_infer_wiki.json>`                             | Basic config for **Russian** language. Consists |
 |                                                                                        | of TF-IDF ranker and reader. Searches for an    |
-|                                                                                        | answer in `ruwiki20180401` Wikipedia dump.      |
+|                                                                                        | answer in ``ruwiki20180401`` Wikipedia dump.    |
 +----------------------------------------------------------------------------------------+-------------------------------------------------+
 |:config:`en_odqa_pop_infer_enwiki20180211 <odqa/en_odqa_pop_infer_enwiki20180211.json>` | Extended config for **English** language.       |
 |                                                                                        | Consists of TF-IDF Ranker, Popularity Ranker    |
 |                                                                                        | and reader. Searches for an answer in           |
-|                                                                                        | `enwiki20180211` Wikipedia dump.                |
+|                                                                                        | ``enwiki20180211`` Wikipedia dump.              |
 +----------------------------------------------------------------------------------------+-------------------------------------------------+
 
 Comparison

--- a/tests/test_configs/doc_retrieval/en_ranker_pop_wiki_test.json
+++ b/tests/test_configs/doc_retrieval/en_ranker_pop_wiki_test.json
@@ -1,0 +1,105 @@
+{
+  "dataset_reader": {
+    "class_name": "odqa_reader",
+    "data_path": "{DOWNLOADS_PATH}/odqa/enwiki_test",
+    "save_path": "{DOWNLOADS_PATH}/odqa/enwiki_test.db",
+    "dataset_format": "txt"
+  },
+  "dataset_iterator": {
+    "class_name": "sqlite_iterator",
+    "shuffle": false,
+    "load_path": "{DOWNLOADS_PATH}/odqa/enwiki_test.db"
+  },
+  "chainer": {
+    "in": [
+      "docs"
+    ],
+    "in_y": [
+      "doc_ids",
+      "doc_nums"
+    ],
+    "out": [
+      "pop_doc_ids"
+    ],
+    "pipe": [
+      {
+        "class_name": "hashing_tfidf_vectorizer",
+        "id": "vectorizer",
+        "fit_on_batch": [
+          "docs",
+          "doc_ids",
+          "doc_nums"
+        ],
+        "save_path": "{DOWNLOADS_PATH}/odqa/enwiki_test_tfidf.npz",
+        "load_path": "{DOWNLOADS_PATH}/odqa/enwiki_test_tfidf.npz",
+        "tokenizer": {
+          "class_name": "stream_spacy_tokenizer",
+          "lemmas": true,
+          "ngram_range": [
+            1,
+            2
+          ]
+        }
+      },
+      {
+        "class_name": "tfidf_ranker",
+        "top_n": 20,
+        "in": [
+          "docs"
+        ],
+        "out": [
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
+        ],
+        "vectorizer": "#vectorizer"
+      },
+      {
+        "class_name": "pop_ranker",
+        "pop_dict_path": "{DOWNLOADS_PATH}/odqa/enwiki20180211_popularities.json",
+        "load_path": "{MODELS_PATH}/odqa/logreg_3features.joblib",
+        "top_n": 10,
+        "in": [
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
+        ],
+        "out": [
+          "pop_doc_ids",
+          "pop_doc_scores"
+        ]
+      }
+    ]
+  },
+  "train": {
+    "validate_best": false,
+    "test_best": false,
+    "batch_size": 10000
+  },
+  "metadata": {
+    "variables": {
+      "ROOT_PATH": "~/.deeppavlov",
+      "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
+      "MODELS_PATH": "{ROOT_PATH}/models"
+    },
+    "requirements": [
+      "{DEEPPAVLOV_PATH}/requirements/spacy.txt",
+      "{DEEPPAVLOV_PATH}/requirements/en_core_web_sm.txt"
+    ],
+    "labels": {
+      "server_utils": "Ranker"
+    },
+    "download": [
+      {
+        "url": "http://files.deeppavlov.ai/datasets/wikipedia/enwiki_test.tar.gz",
+        "subdir": "{DOWNLOADS_PATH}/odqa"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/datasets/wikipedia/enwiki20180211_popularities.tar.gz",
+        "subdir": "{DOWNLOADS_PATH}"
+      },
+      {
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/pop_ranker.tar.gz",
+        "subdir": "{MODELS_PATH}"
+      }
+    ]
+  }
+}

--- a/tests/test_configs/doc_retrieval/en_ranker_tfidf_wiki_test.json
+++ b/tests/test_configs/doc_retrieval/en_ranker_tfidf_wiki_test.json
@@ -19,7 +19,7 @@
       "doc_nums"
     ],
     "out": [
-      "y"
+      "tfidf_doc_ids"
     ],
     "pipe": [
       {
@@ -43,13 +43,13 @@
       },
       {
         "class_name": "tfidf_ranker",
-        "top_n": 5,
+        "top_n": 20,
         "in": [
           "docs"
         ],
         "out": [
-          "y",
-          "score"
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
         ],
         "vectorizer": "#vectorizer"
       }

--- a/tests/test_configs/doc_retrieval/ru_ranker_tfidf_wiki_test.json
+++ b/tests/test_configs/doc_retrieval/ru_ranker_tfidf_wiki_test.json
@@ -19,7 +19,7 @@
       "doc_nums"
     ],
     "out": [
-      "y"
+      "tfidf_doc_ids"
     ],
     "pipe": [
       {
@@ -43,13 +43,13 @@
       },
       {
         "class_name": "tfidf_ranker",
-        "top_n": 5,
+        "top_n": 20,
         "in": [
           "docs"
         ],
         "out": [
-          "y",
-          "score"
+          "tfidf_doc_ids",
+          "tfidf_doc_scores"
         ],
         "vectorizer": "#vectorizer"
       }

--- a/tests/test_configs/odqa/en_odqa_infer_wiki_test.json
+++ b/tests/test_configs/odqa/en_odqa_infer_wiki_test.json
@@ -13,16 +13,16 @@
           "question_raw"
         ],
         "out": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ]
       },
       {
         "class_name": "wiki_sqlite_vocab",
         "in": [
-          "doc_ids"
+          "tfidf_doc_ids"
         ],
         "out": [
-          "context_raw"
+          "tfidf_doc_text"
         ],
         "join_docs": false,
         "shuffle": false,
@@ -30,12 +30,9 @@
       },
       {
         "class_name": "document_chunker",
-        "in": [
-          "context_raw"
-        ],
-        "out": [
-          "chunks"
-        ],
+        "in": ["tfidf_doc_text"],
+        "out": ["chunks"],
+        "tokens_limit": 4000,
         "flatten_result": true
       },
       {
@@ -50,9 +47,8 @@
       },
       {
         "class_name": "logit_ranker",
-        "squad_model": {
-          "config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"
-        },
+        "batch_size": 10,
+        "squad_model": {"config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"},
         "sort_noans": true,
         "in": [
           "chunks",

--- a/tests/test_configs/odqa/en_odqa_infer_wiki_test.json
+++ b/tests/test_configs/odqa/en_odqa_infer_wiki_test.json
@@ -32,8 +32,8 @@
         "class_name": "document_chunker",
         "in": ["tfidf_doc_text"],
         "out": ["chunks"],
-        "tokens_limit": 4000,
-        "flatten_result": true
+        "flatten_result": true,
+        "paragraphs": true
       },
       {
         "class_name": "string_multiplier",

--- a/tests/test_configs/odqa/en_odqa_pop_infer_wiki_test.json
+++ b/tests/test_configs/odqa/en_odqa_pop_infer_wiki_test.json
@@ -1,0 +1,89 @@
+{
+  "chainer": {
+    "in": [
+      "question_raw"
+    ],
+    "out": [
+      "best_answer"
+    ],
+    "pipe": [
+      {
+        "config_path": "{CONFIGS_PATH}/doc_retrieval/en_ranker_pop_wiki_test.json",
+        "in": [
+          "question_raw"
+        ],
+        "out": [
+          "doc_ids"
+        ]
+      },
+      {
+        "class_name": "wiki_sqlite_vocab",
+        "in": [
+          "doc_ids"
+        ],
+        "out": [
+          "context_raw"
+        ],
+        "join_docs": false,
+        "shuffle": false,
+        "load_path": "{DOWNLOADS_PATH}/odqa/enwiki_test.db"
+      },
+      {
+        "class_name": "document_chunker",
+        "in": [
+          "context_raw"
+        ],
+        "out": [
+          "chunks"
+        ],
+        "flatten_result": true
+      },
+      {
+        "class_name": "string_multiplier",
+        "in": [
+          "question_raw",
+          "chunks"
+        ],
+        "out": [
+          "questions"
+        ]
+      },
+      {
+        "class_name": "logit_ranker",
+        "squad_model": {
+          "config_path": "{CONFIGS_PATH}/squad/multi_squad_noans_infer.json"
+        },
+        "sort_noans": true,
+        "in": [
+          "chunks",
+          "questions"
+        ],
+        "out": [
+          "best_answer"
+        ]
+      }
+    ]
+  },
+  "metadata": {
+    "variables": {
+      "ROOT_PATH": "~/.deeppavlov",
+      "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
+      "MODELS_PATH": "{ROOT_PATH}/models",
+      "CONFIGS_PATH": "{DEEPPAVLOV_PATH}/configs"
+    },
+    "requirements": [
+      "{DEEPPAVLOV_PATH}/requirements/tf.txt",
+      "{DEEPPAVLOV_PATH}/requirements/spacy.txt",
+      "{DEEPPAVLOV_PATH}/requirements/en_core_web_sm.txt"
+    ],
+    "labels": {
+      "server_utils": "ODQA"
+    },
+    "download": [
+      {
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/odqa_test.tar.gz",
+        "subdir": "{DOWNLOADS_PATH}"
+      }
+    ]
+  }
+}

--- a/tests/test_configs/odqa/en_odqa_pop_infer_wiki_test.json
+++ b/tests/test_configs/odqa/en_odqa_pop_infer_wiki_test.json
@@ -36,6 +36,7 @@
         "out": [
           "chunks"
         ],
+        "tokens_limit": 4000,
         "flatten_result": true
       },
       {

--- a/tests/test_configs/odqa/ru_odqa_infer_wiki_test.json
+++ b/tests/test_configs/odqa/ru_odqa_infer_wiki_test.json
@@ -36,7 +36,8 @@
         "out": [
           "chunks"
         ],
-        "flatten_result": true
+        "flatten_result": true,
+        "paragraphs": true
       },
       {
         "class_name": "string_multiplier",

--- a/tests/test_quick_start.py
+++ b/tests/test_quick_start.py
@@ -155,7 +155,9 @@ PARAMS = {
     },
     "doc_retrieval": {
         ("doc_retrieval/en_ranker_tfidf_wiki_test.json", "doc_retrieval", ('TI',)): [ONE_ARGUMENT_INFER_CHECK],
-        ("doc_retrieval/ru_ranker_tfidf_wiki_test.json", "doc_retrieval", ('TI',)): [ONE_ARGUMENT_INFER_CHECK]
+        ("doc_retrieval/ru_ranker_tfidf_wiki_test.json", "doc_retrieval", ('TI',)): [ONE_ARGUMENT_INFER_CHECK],
+        ("doc_retrieval/en_ranker_pop_wiki_test.json", "doc_retrieval", ('TI',)): [
+            ONE_ARGUMENT_INFER_CHECK]
     },
     "squad": {
         ("squad/squad.json", "squad_model", ALL_MODES): [TWO_ARGUMENTS_INFER_CHECK],
@@ -181,7 +183,8 @@ PARAMS = {
     },
     "odqa": {
         ("odqa/en_odqa_infer_wiki_test.json", "odqa", ('IP',)): [ONE_ARGUMENT_INFER_CHECK],
-        ("odqa/ru_odqa_infer_wiki_test.json", "odqa", ('IP',)): [ONE_ARGUMENT_INFER_CHECK]
+        ("odqa/ru_odqa_infer_wiki_test.json", "odqa", ('IP',)): [ONE_ARGUMENT_INFER_CHECK],
+        ("odqa/en_odqa_pop_infer_wiki_test.json", "odqa", ('IP',)): [ONE_ARGUMENT_INFER_CHECK]
     },
     "morpho_tagger": {
         ("morpho_tagger/UD2.0/morpho_en.json", "morpho_tagger_en", ALL_MODES): [ONE_ARGUMENT_INFER_CHECK],


### PR DESCRIPTION
- add Pop Ranker for `doc_retrieval` and `odqa`
- change doc splitting strategy from "chunks" to "paragraphs" for configs without Pop Ranker, for the best f1