### PR TITLE
Fix/log

### DIFF
--- a/deeppavlov/core/common/log.py
+++ b/deeppavlov/core/common/log.py
@@ -49,7 +49,7 @@ def get_logger(logger_name):
                 handler['filename'] = str(logfile_path)
 
         logging.config.dictConfig(log_config)
-        logger = logging.getLogger(logger_name)
+        logger = logging.getLogger(f'_dp.{logger_name}')
 
     except Exception:
         logger = logging.getLogger(logger_name)

--- a/deeppavlov/core/common/log.py
+++ b/deeppavlov/core/common/log.py
@@ -35,7 +35,9 @@ def get_logger(logger_name):
         with log_config_path.open(encoding='utf8') as log_config_json:
             log_config = json.load(log_config_json)
 
-        configured_loggers = [log_config.get('root', {})] + log_config.get('loggers', [])
+        configured_loggers = [log_config.get('root', {})] + [logger for logger in
+                                                             log_config.get('loggers', {}).values()]
+
         used_handlers = {handler for log in configured_loggers for handler in log.get('handlers', [])}
 
         for handler_id, handler in list(log_config['handlers'].items()):

--- a/utils/settings/log_config.json
+++ b/utils/settings/log_config.json
@@ -1,37 +1,35 @@
 {
   "version": 1,
-  "disable_existing_loggers": 0,
-  "root":
-  {
-    "level": "DEBUG",
-    "handlers": ["stderr"]
+  "disable_existing_loggers": false,
+  "loggers": {
+    "_dp": {
+      "level": "DEBUG",
+      "handlers": [
+        "stderr"
+      ],
+      "propagate": false
+    }
   },
-  "formatters":
-  {
-    "default":
-    {
+  "formatters": {
+    "default": {
       "format": "%(asctime)s.%(msecs)d %(levelname)s in '%(name)s'['%(module)s'] at line %(lineno)d: %(message)s",
       "datefmt": "%Y-%m-%d %H:%M:%S"
     }
   },
-  "handlers":
-  {
-    "file":
-    {
+  "handlers": {
+    "file": {
       "class": "logging.FileHandler",
       "level": "DEBUG",
       "formatter": "default",
       "filename": "~/.dp_lpg.log"
     },
-    "stdout":
-    {
+    "stdout": {
       "class": "logging.StreamHandler",
       "level": "DEBUG",
       "formatter": "default",
       "stream": "ext://sys.stdout"
     },
-    "stderr":
-    {
+    "stderr": {
       "class": "logging.StreamHandler",
       "level": "DEBUG",
       "formatter": "default",


### PR DESCRIPTION
Fixed bugs in DeepPavlov log:
1. DeepPavlov logger configuration overrided all other loggers in the same process. 
2. Turned of DeepPavlov logger propagation to higher level loggers.