### PR TITLE
Fix/skill wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,15 @@ python -m deeppavlov <mode> <path_to_config> [-d]
 * `<path_to_config>` should be a path to an NLP pipeline json config (e.g. `deeppavlov/configs/ner/slotfill_dstc2.json`)
 or a name without the `.json` extension of one of the config files [provided](deeppavlov/configs) in this repository (e.g. `slotfill_dstc2`)
 
-For the `interactbot` mode you should specify Telegram bot token in `-t` parameter or in `TELEGRAM_TOKEN` environment variable. Also if you want to get custom `/start` and `/help` Telegram messages for the running model you should:
+For the `interactbot` mode you should specify Telegram bot token in `-t` parameter or in `TELEGRAM_TOKEN` environment variable.
+Also you should use `--no-default-skill` optional flag if your component implements an interface of DeepPavlov [*Skill*](deeppavlov/core/skill/skill.py) to skip its wrapping with DeepPavlov [*DefaultStatelessSkill*](deeppavlov/skills/default_skill/default_skill.py).
+If you want to get custom `/start` and `/help` Telegram messages for the running model you should:
 * Add section to [*utils/settings/models_info.json*](utils/settings/models_info.json) with your custom Telegram messages
 * In model config file specify `metadata.labels.telegram_utils` parameter with name which refers to the added section of [*utils/settings/models_info.json*](utils/settings/models_info.json)
 
-For the `interactmsbot` mode you should specify **Microsoft app id** in `-i` and **Microsoft app secret** in `-s`. Also before launch you should specify api deployment settings (host, port) in [*utils/settings/server_config.json*](utils/settings/server_config.json) configuration file. Note, that Microsoft Bot Framework requires `https` endpoint with valid certificate from CA.
-Here is [detailed info on the Microsoft Bot Framework integration](http://docs.deeppavlov.ai/en/latest/devguides/ms_bot_integration.html)
-
-You can also store your tokens, app ids, secrets in appropriate sections of [*utils/settings/server_config.json*](utils/settings/server_config.json). Please note, that all command line parameters override corresponding config ones.
+You can also make available DeepPavlov pre-train models in:
+* Microsoft Bot Framework ([see developer guide for the detailed instructions](http://docs.deeppavlov.ai/en/latest/devguides/ms_bot_integration.html)) 
+* Amazon Alexa ([see developer guide for the detailed instructions](http://docs.deeppavlov.ai/en/latest/devguides/amazon_alexa.html)) 
 
 For `riseapi` mode you should specify api settings (host, port, etc.) in [*utils/settings/server_config.json*](utils/settings/server_config.json) configuration file. If provided, values from *model_defaults* section override values for the same parameters from *common_defaults* section. Model names in *model_defaults* section should be similar to the class names of the models main component.
 Here is [detailed info on the DeepPavlov REST API](http://docs.deeppavlov.ai/en/latest/devguides/rest_api.html)

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ If you want to get custom `/start` and `/help` Telegram messages for the running
 * Add section to [*utils/settings/models_info.json*](utils/settings/models_info.json) with your custom Telegram messages
 * In model config file specify `metadata.labels.telegram_utils` parameter with name which refers to the added section of [*utils/settings/models_info.json*](utils/settings/models_info.json)
 
-You can also make available DeepPavlov pre-train models in:
+You can also serve DeepPavlov models for:
 * Microsoft Bot Framework ([see developer guide for the detailed instructions](http://docs.deeppavlov.ai/en/latest/devguides/ms_bot_integration.html)) 
 * Amazon Alexa ([see developer guide for the detailed instructions](http://docs.deeppavlov.ai/en/latest/devguides/amazon_alexa.html)) 
 

--- a/deeppavlov/agents/default_agent/default_agent.py
+++ b/deeppavlov/agents/default_agent/default_agent.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from deeppavlov.agents.filters.transparent_filter import TransparentFilter
 from deeppavlov.agents.processors.highest_confidence_selector import HighestConfidenceSelector
@@ -47,11 +47,11 @@ class DefaultAgent(Agent):
         skills_processor: Initiated agent processor.
         skills_filter: Initiated agent filter.
     """
-    def __init__(self, skills: List[Component], skills_processor: Optional[Processor]=None,
-                 skills_filter: Optional[Filter]=None, *args, **kwargs) -> None:
+    def __init__(self, skills: List[Component], skills_processor: Optional[Processor] = None,
+                 skills_filter: Optional[Filter] = None, *args, **kwargs) -> None:
         super(DefaultAgent, self).__init__(skills=skills)
-        self.skills_filter: Filter = skills_filter or TransparentFilter(len(skills))
-        self.skills_processor: Processor = skills_processor or HighestConfidenceSelector()
+        self.skills_filter = skills_filter or TransparentFilter(len(skills))
+        self.skills_processor = skills_processor or HighestConfidenceSelector()
 
     def _call(self, utterances_batch: list, utterances_ids: Optional[list]=None) -> list:
         """

--- a/deeppavlov/agents/default_agent/default_agent.py
+++ b/deeppavlov/agents/default_agent/default_agent.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from deeppavlov.agents.filters.transparent_filter import TransparentFilter
 from deeppavlov.agents.processors.highest_confidence_selector import HighestConfidenceSelector
@@ -20,6 +20,7 @@ from deeppavlov.core.agent.agent import Agent
 from deeppavlov.core.agent.filter import Filter
 from deeppavlov.core.agent.processor import Processor
 from deeppavlov.core.skill.skill import Skill
+from deeppavlov.core.models.component import Component
 
 
 class DefaultAgent(Agent):
@@ -47,7 +48,7 @@ class DefaultAgent(Agent):
         skills_processor: Initiated agent processor.
         skills_filter: Initiated agent filter.
     """
-    def __init__(self, skills: List[Skill], skills_processor: Optional[Processor]=None,
+    def __init__(self, skills: Union[List[Skill], List[Component]], skills_processor: Optional[Processor]=None,
                  skills_filter: Optional[Filter]=None, *args, **kwargs) -> None:
         super(DefaultAgent, self).__init__(skills=skills)
         self.skills_filter: Filter = skills_filter or TransparentFilter(len(skills))

--- a/deeppavlov/agents/default_agent/default_agent.py
+++ b/deeppavlov/agents/default_agent/default_agent.py
@@ -19,7 +19,6 @@ from deeppavlov.agents.processors.highest_confidence_selector import HighestConf
 from deeppavlov.core.agent.agent import Agent
 from deeppavlov.core.agent.filter import Filter
 from deeppavlov.core.agent.processor import Processor
-from deeppavlov.core.skill.skill import Skill
 from deeppavlov.core.models.component import Component
 
 
@@ -39,7 +38,7 @@ class DefaultAgent(Agent):
     You can refer to :class:`deeppavlov.core.skill.Skill`, :class:`deeppavlov.core.agent.Filter`, :class:`deeppavlov.core.agent.Processor` base classes to get more info.
 
     Args:
-        skills: List of initiated agent skills instances.
+        skills: List of initiated agent skills or components instances.
         skills_processor: Initiated agent processor.
         skills_filter: Initiated agent filter.
 
@@ -48,7 +47,7 @@ class DefaultAgent(Agent):
         skills_processor: Initiated agent processor.
         skills_filter: Initiated agent filter.
     """
-    def __init__(self, skills: Union[List[Skill], List[Component]], skills_processor: Optional[Processor]=None,
+    def __init__(self, skills: List[Component], skills_processor: Optional[Processor]=None,
                  skills_filter: Optional[Filter]=None, *args, **kwargs) -> None:
         super(DefaultAgent, self).__init__(skills=skills)
         self.skills_filter: Filter = skills_filter or TransparentFilter(len(skills))

--- a/deeppavlov/core/agent/agent.py
+++ b/deeppavlov/core/agent/agent.py
@@ -35,7 +35,7 @@ class Agent(Component, metaclass=ABCMeta):
         skills: List of initiated agent skills instances.
 
     Attributes:
-        skills: List of initiated agent skill or component instances.
+        skills: List of initiated Skill or Component instances.
             Components API should should implement API of Skill abstract class.
         history: Histories for each each dialog with agent indexed
             by dialog ID. Each history is represented by list of incoming
@@ -51,7 +51,7 @@ class Agent(Component, metaclass=ABCMeta):
             We highly recommend to use wrapped skills for skills inference.
         dialog_logger: DeepPavlov dialog logging facility.
     """
-    def __init__(self, skills: List[Skill]) -> None:
+    def __init__(self, skills: List[Component]) -> None:
         self.skills: Union[List[Skill], List[Component]] = skills
         self.history: Dict = defaultdict(list)
         self.states: Dict = defaultdict(lambda: [None] * len(self.skills))

--- a/deeppavlov/core/agent/agent.py
+++ b/deeppavlov/core/agent/agent.py
@@ -18,7 +18,6 @@ from typing import List, Dict, Tuple, Optional, Union
 
 from deeppavlov.core.agent.dialog_logger import DialogLogger
 from deeppavlov.core.models.component import Component
-from deeppavlov.core.skill.skill import Skill
 
 
 class Agent(Component, metaclass=ABCMeta):
@@ -52,7 +51,7 @@ class Agent(Component, metaclass=ABCMeta):
         dialog_logger: DeepPavlov dialog logging facility.
     """
     def __init__(self, skills: List[Component]) -> None:
-        self.skills: Union[List[Skill], List[Component]] = skills
+        self.skills: List[Component] = skills
         self.history: Dict = defaultdict(list)
         self.states: Dict = defaultdict(lambda: [None] * len(self.skills))
         self.wrapped_skills: List[SkillWrapper] = \
@@ -119,7 +118,7 @@ class SkillWrapper:
         skill_id: Skill index in Agent.skills list.
         agent: Agent instance.
     """
-    def __init__(self, skill: Skill, skill_id: int, agent: Agent) -> None:
+    def __init__(self, skill: Component, skill_id: int, agent: Agent) -> None:
         self.skill = skill
         self.skill_id = skill_id
         self.agent = agent

--- a/deeppavlov/core/agent/agent.py
+++ b/deeppavlov/core/agent/agent.py
@@ -14,7 +14,7 @@
 
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
-from typing import List, Dict, Tuple, Optional
+from typing import List, Dict, Tuple, Optional, Union
 
 from deeppavlov.core.agent.dialog_logger import DialogLogger
 from deeppavlov.core.models.component import Component
@@ -35,7 +35,8 @@ class Agent(Component, metaclass=ABCMeta):
         skills: List of initiated agent skills instances.
 
     Attributes:
-        skills: List of initiated agent skills instances.
+        skills: List of initiated agent skill or component instances.
+            Components API should should implement API of Skill abstract class.
         history: Histories for each each dialog with agent indexed
             by dialog ID. Each history is represented by list of incoming
             and outcoming replicas of the dialog and updated automatically.
@@ -51,7 +52,7 @@ class Agent(Component, metaclass=ABCMeta):
         dialog_logger: DeepPavlov dialog logging facility.
     """
     def __init__(self, skills: List[Skill]) -> None:
-        self.skills: List[Skill] = skills
+        self.skills: Union[List[Skill], List[Component]] = skills
         self.history: Dict = defaultdict(list)
         self.states: Dict = defaultdict(lambda: [None] * len(self.skills))
         self.wrapped_skills: List[SkillWrapper] = \

--- a/deeppavlov/core/agent/agent.py
+++ b/deeppavlov/core/agent/agent.py
@@ -51,7 +51,7 @@ class Agent(Component, metaclass=ABCMeta):
         dialog_logger: DeepPavlov dialog logging facility.
     """
     def __init__(self, skills: List[Component]) -> None:
-        self.skills: List[Component] = skills
+        self.skills = skills
         self.history: Dict = defaultdict(list)
         self.states: Dict = defaultdict(lambda: [None] * len(self.skills))
         self.wrapped_skills: List[SkillWrapper] = \

--- a/deeppavlov/deep.py
+++ b/deeppavlov/deep.py
@@ -91,7 +91,9 @@ def main():
         interact_model(pipeline_config_path)
     elif args.mode == 'interactbot':
         token = args.token
-        interact_model_by_telegram(pipeline_config_path, token)
+        interact_model_by_telegram(model_config=pipeline_config_path,
+                                   token=token,
+                                   default_skill_wrap=not args.no_default_skill)
     elif args.mode == 'interactmsbot':
         ms_id = args.ms_id
         ms_secret = args.ms_secret

--- a/deeppavlov/deep.py
+++ b/deeppavlov/deep.py
@@ -103,6 +103,9 @@ def main():
                                 multi_instance=multi_instance,
                                 stateful=stateful,
                                 port=args.port,
+                                https=https,
+                                ssl_key=ssl_key,
+                                ssl_cert=ssl_cert,
                                 default_skill_wrap=not args.no_default_skill)
     elif args.mode == 'alexa':
         run_alexa_default_agent(model_config=pipeline_config_path,

--- a/deeppavlov/deep.py
+++ b/deeppavlov/deep.py
@@ -53,7 +53,7 @@ parser.add_argument("-s", "--ms-secret", default=None, help="microsoft bot frame
 
 parser.add_argument("--multi-instance", action="store_true", help="allow rising of several instances of the model")
 parser.add_argument("--stateful", action="store_true", help="interact with a stateful model")
-parser.add_argument("--default-skill", action="store_true", help="wrap with default skill")
+parser.add_argument("--no-default-skill", action="store_true", help="do not wrap with default skill")
 
 parser.add_argument("--https", action="store_true", help="run model in https mode")
 parser.add_argument("--key", default=None, help="ssl key", type=str)
@@ -101,7 +101,7 @@ def main():
                                 multi_instance=multi_instance,
                                 stateful=stateful,
                                 port=args.port,
-                                default_skill_wrap=args.default_skill)
+                                default_skill_wrap=not args.no_default_skill)
     elif args.mode == 'alexa':
         run_alexa_default_agent(model_config=pipeline_config_path,
                                 multi_instance=multi_instance,

--- a/deeppavlov/deep.py
+++ b/deeppavlov/deep.py
@@ -53,6 +53,7 @@ parser.add_argument("-s", "--ms-secret", default=None, help="microsoft bot frame
 
 parser.add_argument("--multi-instance", action="store_true", help="allow rising of several instances of the model")
 parser.add_argument("--stateful", action="store_true", help="interact with a stateful model")
+parser.add_argument("--default-skill", action="store_true", help="wrap with default skill")
 
 parser.add_argument("--https", action="store_true", help="run model in https mode")
 parser.add_argument("--key", default=None, help="ssl key", type=str)
@@ -99,7 +100,8 @@ def main():
                                 app_secret=ms_secret,
                                 multi_instance=multi_instance,
                                 stateful=stateful,
-                                port=args.port)
+                                port=args.port,
+                                default_skill_wrap=args.default_skill)
     elif args.mode == 'alexa':
         run_alexa_default_agent(model_config=pipeline_config_path,
                                 multi_instance=multi_instance,

--- a/deeppavlov/deep.py
+++ b/deeppavlov/deep.py
@@ -109,7 +109,8 @@ def main():
                                 port=args.port,
                                 https=https,
                                 ssl_key=ssl_key,
-                                ssl_cert=ssl_cert)
+                                ssl_cert=ssl_cert,
+                                default_skill_wrap=not args.no_default_skill)
     elif args.mode == 'riseapi':
         alice = args.api_mode == 'alice'
         if alice:

--- a/docs/devguides/amazon_alexa.rst
+++ b/docs/devguides/amazon_alexa.rst
@@ -189,7 +189,7 @@ DeepPavlov skill/component can be made available for Amazon Alexa as a REST serv
     python -m deeppavlov alexa <config_path> --https --key <SSL key file path> --cert <SSL certificate file path> [-d] [-p <port_number>] [--no-default-skill]
 
 If you redirect requests to your skills service from some https endpoint, you may want to run it in http mode by
-omitting ``https``, ``key``, ``cert`` keys.
+omitting ``--https``, ``--key``, ``--cert`` keys.
 
 Optional ``-d`` key can be provided for dependencies download
 before service start.

--- a/docs/devguides/amazon_alexa.rst
+++ b/docs/devguides/amazon_alexa.rst
@@ -186,13 +186,18 @@ DeepPavlov skill/component can be made available for Amazon Alexa as a REST serv
 
 .. code:: bash
 
-    python -m deeppavlov alexa <config_path> -p <port> --https --key <SSL key file path> --cert <SSL certificate file path> [-d]
+    python -m deeppavlov alexa <config_path> --https --key <SSL key file path> --cert <SSL certificate file path> [-d] [-p <port_number>] [--no-default-skill]
 
 If you redirect requests to your skills service from some https endpoint, you may want to run it in http mode by
 omitting ``https``, ``key``, ``cert`` keys.
 
 Optional ``-d`` key can be provided for dependencies download
 before service start.
+
+Optional ``-p`` key can be provided to override the port value from a settings file.
+
+You should use ``--no-default-skill`` optional flag if your component implements an interface of DeepPavlov *Skill*
+to skip its wrapping with DeepPavlov *DefaultStatelessSkill*.
 
 REST service properties (host, port, https options) are provided in ``utils/settings/server_config.json``. Please note,
 that all command line parameters override corresponding config ones.

--- a/docs/devguides/ms_bot_integration.rst
+++ b/docs/devguides/ms_bot_integration.rst
@@ -83,10 +83,13 @@ as a REST service by:
 
 .. code:: bash
 
-    python -m deeppavlov interactmsbot -i <microsoft_app_id> -s <microsoft_app_secret> <config_path> [-d] [-p <port_number>] [--no-default-skill]
+    python -m deeppavlov interactmsbot <config_path> -i <microsoft_app_id> -s <microsoft_app_secret> --https --key <SSL key file path> --cert <SSL certificate file path> [-d] [-p <port_number>] [--no-default-skill]
 
 Use *Microsoft App ID* and *Microsoft App Secret* obtained
 in the **Web App Bot connection configuration** section.
+
+If you redirect requests to your skills service from some https endpoint, you may want to run it in http mode by
+omitting ``https``, ``key``, ``cert`` keys.
 
 Optional ``-d`` key can be provided for dependencies download
 before service start.

--- a/docs/devguides/ms_bot_integration.rst
+++ b/docs/devguides/ms_bot_integration.rst
@@ -89,7 +89,7 @@ Use *Microsoft App ID* and *Microsoft App Secret* obtained
 in the **Web App Bot connection configuration** section.
 
 If you redirect requests to your skills service from some https endpoint, you may want to run it in http mode by
-omitting ``https``, ``key``, ``cert`` keys.
+omitting ``--https``, ``--key``, ``--cert`` keys.
 
 Optional ``-d`` key can be provided for dependencies download
 before service start.

--- a/docs/devguides/ms_bot_integration.rst
+++ b/docs/devguides/ms_bot_integration.rst
@@ -81,13 +81,20 @@ with valid certificate from CA.
 Each DeepPavlov skill/component can be made available for MS Bot Framework
 as a REST service by:
 
-``python -m deeppavlov interactmsbot -i <microsoft_app_id> -s <microsoft_app_secret> <config_path> [-d] [-p <port_number>]``
+.. code:: bash
+
+    python -m deeppavlov interactmsbot -i <microsoft_app_id> -s <microsoft_app_secret> <config_path> [-d] [-p <port_number>] [--no-default-skill]
 
 Use *Microsoft App ID* and *Microsoft App Secret* obtained
 in the **Web App Bot connection configuration** section.
+
 Optional ``-d`` key can be provided for dependencies download
 before service start.
+
 Optional ``-p`` key can be provided to override the port value from a settings file.
+
+You should use ``--no-default-skill`` optional flag if your component implements an interface of DeepPavlov *Skill*
+to skip its wrapping with DeepPavlov *DefaultStatelessSkill*.
 
 REST service properties (host, port) are provided in ``utils/settings/server_config.json``. You can also store your
 app id and app secret in appropriate section of ``server_config.json``. Please note, that all command line parameters

--- a/utils/alexa/server.py
+++ b/utils/alexa/server.py
@@ -63,6 +63,7 @@ def run_alexa_default_agent(model_config: Union[str, Path, dict],
         https: Flag for running Alexa skill service in https mode.
         ssl_key: SSL key file path.
         ssl_cert: SSL certificate file path.
+        default_skill_wrap: Wrap with default skill flag.
     """
 
     def get_default_agent() -> DefaultAgent:

--- a/utils/alexa/server.py
+++ b/utils/alexa/server.py
@@ -81,9 +81,13 @@ def run_alexa_default_agent(model_config: Union[str, Path, dict],
                      ssl_cert=ssl_cert)
 
 
-def run_alexa_server(agent_generator: callable, multi_instance: bool = False,
-                     stateful: bool = False, port: Optional[int] = None, https: bool = False,
-                     ssl_key: str = None, ssl_cert: str = None) -> None:
+def run_alexa_server(agent_generator: callable,
+                     multi_instance: bool = False,
+                     stateful: bool = False,
+                     port: Optional[int] = None,
+                     https: bool = False,
+                     ssl_key: str = None,
+                     ssl_cert: str = None) -> None:
     """Initiates Flask web service with Alexa skill.
 
     Args:

--- a/utils/alexa/server.py
+++ b/utils/alexa/server.py
@@ -42,9 +42,14 @@ Swagger(app)
 CORS(app)
 
 
-def run_alexa_default_agent(model_config: Union[str, Path, dict], multi_instance: bool = False,
-                            stateful: bool = False, port: Optional[int] = None, https: bool = False,
-                            ssl_key: str = None, ssl_cert: str = None) -> None:
+def run_alexa_default_agent(model_config: Union[str, Path, dict],
+                            multi_instance: bool = False,
+                            stateful: bool = False,
+                            port: Optional[int] = None,
+                            https: bool = False,
+                            ssl_key: str = None,
+                            ssl_cert: str = None,
+                            default_skill_wrap: bool = True) -> None:
     """Creates Alexa agents factory and initiates Alexa web service.
 
     Wrapper around run_alexa_server. Allows raise Alexa web service with
@@ -62,7 +67,7 @@ def run_alexa_default_agent(model_config: Union[str, Path, dict], multi_instance
 
     def get_default_agent() -> DefaultAgent:
         model = build_model(model_config)
-        skill = DefaultStatelessSkill(model)
+        skill = DefaultStatelessSkill(model) if default_skill_wrap else model
         agent = DefaultAgent([skill], skills_processor=DefaultRichContentWrapper())
         return agent
 

--- a/utils/ms_bot_framework_utils/server.py
+++ b/utils/ms_bot_framework_utils/server.py
@@ -35,7 +35,7 @@ def run_ms_bf_default_agent(model_config: Union[str, Path, dict],
                             multi_instance: bool = False,
                             stateful: bool = False,
                             port: Optional[int] = None,
-                            default_skill_wrap: bool = False):
+                            default_skill_wrap: bool = True):
 
     def get_default_agent():
         model = build_model(model_config)

--- a/utils/ms_bot_framework_utils/server.py
+++ b/utils/ms_bot_framework_utils/server.py
@@ -46,8 +46,12 @@ def run_ms_bf_default_agent(model_config: Union[str, Path, dict],
     run_ms_bot_framework_server(get_default_agent, app_id, app_secret, multi_instance, stateful, port=port)
 
 
-def run_ms_bot_framework_server(agent_generator: callable, app_id: str, app_secret: str,
-                                multi_instance: bool = False, stateful: bool = False, port: Optional[int] = None):
+def run_ms_bot_framework_server(agent_generator: callable,
+                                app_id: str,
+                                app_secret: str,
+                                multi_instance: bool = False,
+                                stateful: bool = False,
+                                port: Optional[int] = None):
 
     server_config_path = Path(get_settings_path(), SERVER_CONFIG_FILENAME).resolve()
     server_params = read_json(server_config_path)

--- a/utils/ms_bot_framework_utils/server.py
+++ b/utils/ms_bot_framework_utils/server.py
@@ -35,7 +35,7 @@ def run_ms_bf_default_agent(model_config: Union[str, Path, dict],
                             multi_instance: bool = False,
                             stateful: bool = False,
                             port: Optional[int] = None,
-                            default_skill_wrap: bool = True):
+                            default_skill_wrap: bool = False):
 
     def get_default_agent():
         model = build_model(model_config)

--- a/utils/ms_bot_framework_utils/server.py
+++ b/utils/ms_bot_framework_utils/server.py
@@ -30,11 +30,16 @@ Swagger(app)
 CORS(app)
 
 
-def run_ms_bf_default_agent(model_config: Union[str, Path, dict], app_id: str, app_secret: str,
-                            multi_instance: bool = False, stateful: bool = False, port: Optional[int] = None):
+def run_ms_bf_default_agent(model_config: Union[str, Path, dict],
+                            app_id: str, app_secret: str,
+                            multi_instance: bool = False,
+                            stateful: bool = False,
+                            port: Optional[int] = None,
+                            default_skill_wrap: bool = True):
+
     def get_default_agent():
         model = build_model(model_config)
-        skill = DefaultStatelessSkill(model)
+        skill = DefaultStatelessSkill(model) if default_skill_wrap else model
         agent = DefaultAgent([skill], skills_processor=DefaultRichContentWrapper())
         return agent
 

--- a/utils/telegram_utils/telegram_ui.py
+++ b/utils/telegram_utils/telegram_ui.py
@@ -15,6 +15,7 @@ limitations under the License.
 """
 from logging import getLogger
 from pathlib import Path
+from typing import Union
 
 import telebot
 
@@ -65,18 +66,22 @@ def init_bot_for_model(agent: Agent, token: str, model_name: str):
     bot.polling()
 
 
-def interact_model_by_telegram(config, token=None):
+def interact_model_by_telegram(model_config: Union[str, Path, dict],
+                               token=None,
+                               default_skill_wrap: bool = True):
+
     server_config_path = Path(get_settings_path(), SERVER_CONFIG_FILENAME)
     server_config = read_json(server_config_path)
     token = token if token else server_config['telegram_defaults']['token']
+
     if not token:
         e = ValueError('Telegram token required: initiate -t param or telegram_defaults/token '
                        'in server configuration file')
         log.error(e)
         raise e
 
-    model = build_model(config)
+    model = build_model(model_config)
     model_name = type(model.get_main_component()).__name__
-    skill = DefaultStatelessSkill(model)
+    skill = DefaultStatelessSkill(model) if default_skill_wrap else model
     agent = DefaultAgent([skill], skills_processor=DefaultRichContentWrapper())
     init_bot_for_model(agent, token, model_name)


### PR DESCRIPTION
1) Added `--no-default-skill` command line param to omit wrapping component to `DefaultStatelessSkill` if component implements `Skill` interface. Is available for `interactbot`, `interactmsbot`, `alexa` modes.

2)  Added `--https` mode to `interactmsbot` mode.

3) Beautified docs.