### PR TITLE
Feat/str rich content

### DIFF
--- a/deeppavlov/agents/rich_content/default_rich_content.py
+++ b/deeppavlov/agents/rich_content/default_rich_content.py
@@ -30,6 +30,9 @@ class PlainText(RichControl):
         super(PlainText, self).__init__('plain_text')
         self.content: str = text
 
+    def __str__(self, *args, **kwargs) -> str:
+        return self.content
+
     def json(self) -> dict:
         """Returns json compatible state of the PlainText instance.
 

--- a/deeppavlov/agents/rich_content/default_rich_content.py
+++ b/deeppavlov/agents/rich_content/default_rich_content.py
@@ -30,7 +30,7 @@ class PlainText(RichControl):
         super(PlainText, self).__init__('plain_text')
         self.content: str = text
 
-    def __str__(self, *args, **kwargs) -> str:
+    def __str__(self) -> str:
         return self.content
 
     def json(self) -> dict:

--- a/deeppavlov/core/agent/agent.py
+++ b/deeppavlov/core/agent/agent.py
@@ -38,7 +38,7 @@ class Agent(Component, metaclass=ABCMeta):
             Components API should should implement API of Skill abstract class.
         history: Histories for each each dialog with agent indexed
             by dialog ID. Each history is represented by list of incoming
-            and outcoming replicas of the dialog and updated automatically.
+            and outcoming replicas of the dialog casted to str and updated automatically.
         states: States for each skill with agent indexed by dialog ID. Each
             state updated automatically after each wrapped skill inference.
             So we highly recommend use this attribute only for reading and
@@ -75,10 +75,10 @@ class Agent(Component, metaclass=ABCMeta):
         ids = utterances_ids or list(range(batch_size))
 
         for utt_batch_idx, utt_id in enumerate(ids):
-            self.history[utt_id].append(utterances_batch[utt_batch_idx])
+            self.history[utt_id].append(str(utterances_batch[utt_batch_idx]))
             self.dialog_logger.log_in(utterances_batch[utt_batch_idx], utt_id)
 
-            self.history[utt_id].append(responses_batch[utt_batch_idx])
+            self.history[utt_id].append(str(responses_batch[utt_batch_idx]))
             self.dialog_logger.log_out(responses_batch[utt_batch_idx], utt_id)
 
         return responses_batch

--- a/deeppavlov/core/agent/rich_content.py
+++ b/deeppavlov/core/agent/rich_content.py
@@ -82,7 +82,7 @@ class RichControl(RichItem, metaclass=ABCMeta):
         self.content = None
         self.control_json: dict = {'type': control_type, 'content': None}
 
-    def __str__(self, *args, **kwargs) -> str:
+    def __str__(self) -> str:
         return ''
 
 
@@ -100,7 +100,7 @@ class RichMessage(RichItem):
     def __init__(self) -> None:
         self.controls: list = []
 
-    def __str__(self, *args, **kwargs) -> str:
+    def __str__(self) -> str:
         result = '\n'.join(filter(bool, map(str, self.controls)))
         return result
 

--- a/deeppavlov/core/agent/rich_content.py
+++ b/deeppavlov/core/agent/rich_content.py
@@ -102,7 +102,7 @@ class RichMessage(RichItem):
 
     def __str__(self, *args, **kwargs):
         result = '\n'.join([str(control) for control in self.controls if str(control)])
-        return result or ''
+        return result
 
     def add_control(self, control: RichControl):
         """Adds RichControl instance to RichMessage.

--- a/deeppavlov/core/agent/rich_content.py
+++ b/deeppavlov/core/agent/rich_content.py
@@ -101,7 +101,7 @@ class RichMessage(RichItem):
         self.controls: list = []
 
     def __str__(self, *args, **kwargs):
-        result = '\n'.join([str(control) for control in self.controls if str(control)])
+        result = '\n'.join(filter(bool, map(str, self.controls)))
         return result
 
     def add_control(self, control: RichControl):

--- a/deeppavlov/core/agent/rich_content.py
+++ b/deeppavlov/core/agent/rich_content.py
@@ -100,7 +100,7 @@ class RichMessage(RichItem):
     def __init__(self) -> None:
         self.controls: list = []
 
-    def __str__(self, *args, **kwargs):
+    def __str__(self, *args, **kwargs) -> str:
         result = '\n'.join(filter(bool, map(str, self.controls)))
         return result
 

--- a/deeppavlov/core/agent/rich_content.py
+++ b/deeppavlov/core/agent/rich_content.py
@@ -82,6 +82,9 @@ class RichControl(RichItem, metaclass=ABCMeta):
         self.content = None
         self.control_json: dict = {'type': control_type, 'content': None}
 
+    def __str__(self, *args, **kwargs) -> str:
+        return ''
+
 
 class RichMessage(RichItem):
     """Container for rich controls.
@@ -96,6 +99,10 @@ class RichMessage(RichItem):
 
     def __init__(self) -> None:
         self.controls: list = []
+
+    def __str__(self, *args, **kwargs):
+        result = '\n'.join([str(control) for control in self.controls if str(control)])
+        return result or ''
 
     def add_control(self, control: RichControl):
         """Adds RichControl instance to RichMessage.


### PR DESCRIPTION
For now DeepPavlov developers expect only str typed utterances and responses to be stored in Agent history. To meet these expectations:
1) RichMessage and RichControl implement __str__ method;
2) Agent utterances and responses are explicitly casted to str when put to agent history.