### PR TITLE
Add a config name to a download url

### DIFF
--- a/deeppavlov/core/data/utils.py
+++ b/deeppavlov/core/data/utils.py
@@ -26,7 +26,7 @@ from itertools import chain
 from logging import getLogger
 from pathlib import Path
 from typing import List, Union, Iterable, Optional
-from urllib.parse import urlparse
+from urllib.parse import urlencode, parse_qs, urlsplit, urlunsplit, urlparse
 
 import numpy as np
 import requests
@@ -441,3 +441,36 @@ def update_dict_recursive(editable_dict: dict, editing_dict: dict) -> None:
         else:
             editable_dict[k] = v
 
+
+def path_set_md5(url):
+    """Given a file URL, return a md5 query of the file
+
+    Args:
+        url: a given URL
+    Returns:
+        URL of the md5 file
+    """
+    scheme, netloc, path, query_string, fragment = urlsplit(url)
+    path += '.md5'
+
+    return urlunsplit((scheme, netloc, path, query_string, fragment))
+
+
+def set_query_parameter(url, param_name, param_value):
+    """Given a URL, set or replace a query parameter and return the modified URL.
+
+    Args:
+        url: a given  URL
+        param_name: the parameter name to add
+        param_value: the parameter value
+    Returns:
+        URL with the added parameter
+
+    """
+    scheme, netloc, path, query_string, fragment = urlsplit(url)
+    query_params = parse_qs(query_string)
+
+    query_params[param_name] = [param_value]
+    new_query_string = urlencode(query_params, doseq=True)
+
+    return urlunsplit((scheme, netloc, path, new_query_string, fragment))

--- a/deeppavlov/download.py
+++ b/deeppavlov/download.py
@@ -141,8 +141,8 @@ def deep_download(config: Union[str, Path, dict]) -> None:
     downloads = get_configs_downloads(config)
 
     for url, dest_paths in downloads.items():
-        if isinstance(config, Path):
-            url = set_query_parameter(url, 'config', config.stem)
+        if not isinstance(config, dict):
+            url = set_query_parameter(url, 'config', Path(config).stem)
         download_resource(url, dest_paths)
 
 

--- a/deeppavlov/download.py
+++ b/deeppavlov/download.py
@@ -146,7 +146,7 @@ def deep_download(config: Union[str, Path, dict]) -> None:
     downloads = get_configs_downloads(config)
 
     for url, dest_paths in downloads.items():
-        url += "?" + config.stem
+        url += "?config=" + config.stem
         download_resource(url, dest_paths)
 
 

--- a/deeppavlov/download.py
+++ b/deeppavlov/download.py
@@ -141,7 +141,8 @@ def deep_download(config: Union[str, Path, dict]) -> None:
     downloads = get_configs_downloads(config)
 
     for url, dest_paths in downloads.items():
-        url = set_query_parameter(url, 'config', config.stem)
+        if isinstance(config, Path):
+            url = set_query_parameter(url, 'config', config.stem)
         download_resource(url, dest_paths)
 
 

--- a/deeppavlov/download.py
+++ b/deeppavlov/download.py
@@ -24,7 +24,7 @@ import requests
 
 import deeppavlov
 from deeppavlov.core.commands.utils import expand_path, parse_config
-from deeppavlov.core.data.utils import download, download_decompress, get_all_elems_from_json, file_md5
+from deeppavlov.core.data.utils import download, download_decompress, get_all_elems_from_json, file_md5, set_query_parameter, path_set_md5
 
 log = getLogger(__name__)
 
@@ -76,11 +76,7 @@ def get_configs_downloads(config: Optional[Union[str, Path, dict]]=None) -> Dict
 
 
 def check_md5(url: str, dest_paths: List[Path]) -> bool:
-    if "?" in url:
-        url_md5 = url.replace("?", '.md5?')
-    else:
-        url_md5 = url + '.md5'
-
+    url_md5 = path_set_md5(url)
     r = requests.get(url_md5)
     if r.status_code != 200:
         return False
@@ -124,7 +120,6 @@ def download_resource(url: str, dest_paths: Iterable[Path]) -> None:
     else:
         file_name = url.split('/')[-1].split('?')[0]
         dest_files = [dest_path / file_name for dest_path in dest_paths]
-        print(dest_files)
         download(dest_files, url)
 
 
@@ -146,7 +141,7 @@ def deep_download(config: Union[str, Path, dict]) -> None:
     downloads = get_configs_downloads(config)
 
     for url, dest_paths in downloads.items():
-        url += "?config=" + config.stem
+        url = set_query_parameter(url, 'config', config.stem)
         download_resource(url, dest_paths)
 
 


### PR DESCRIPTION
In order to pair the requested file to download with corresponding config file, the config name is added to the requested file url, for instance 

http://files.deeppavlov.ai/deeppavlov_data/ner_conll2003_v4_cpu_compatible.tar.gz?config=ner_conll2003