### PR TITLE
NameError: name 'fastText' is not defined

### DIFF
--- a/deeppavlov/models/embedders/fasttext_embedder.py
+++ b/deeppavlov/models/embedders/fasttext_embedder.py
@@ -16,7 +16,7 @@ from overrides import overrides
 from typing import Iterator
 
 import numpy as np
-import fastText
+import fasttext as fastText
 
 from deeppavlov.core.common.registry import register
 from deeppavlov.core.common.log import get_logger


### PR DESCRIPTION
Linux debian 4.19.0-2-amd64 #1 SMP Debian 4.19.16-1 (2019-01-17) x86_64 GNU/Linux
python 


- apt install libssl-dev libncurses5-dev libsqlite3-dev libreadline-dev libtk8.5 libgdm-dev libdb4o-cil-dev libpcap-dev
wget https://www.python.org/ftp/python/3.6.8/Python-3.6.8rc1.tgz
- tar -xvzf
- cd Python-3.6.8
- ./configure --enable-optimizations --with-ensurepip=install
- make -j8
- sudo make altinstall
- python3.6
- update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
- update-alternatives --config python
- python -m pip install --upgrade pip
- git config --global http.proxy http://srv-proxy:8080
- git clone https://github.com/deepmipt/DeepPavlov.git
ver 1
- pip3.6 install virtualenv --user
- ~/.local/bin/virtualenv ENV
- source ENV/bin/activate 