### PR TITLE
fix: concat dimension for cnn_bilstm_model

### DIFF
--- a/deeppavlov/models/classifiers/keras_classification_model.py
+++ b/deeppavlov/models/classifiers/keras_classification_model.py
@@ -754,7 +754,7 @@ class KerasClassificationModel(LRScheduledKerasModel):
             output_i = MaxPooling1D()(output_i)
             outputs.append(output_i)
 
-        output = concatenate(outputs, axis=1)
+        output = concatenate(outputs, axis=-1)
         output = Dropout(rate=dropout_rate)(output)
 
         output = Bidirectional(LSTM(units_lstm, activation='tanh',


### PR DESCRIPTION
Found mistake in concatenation axis in one of keras_classification_model methods