### PR TITLE
Jenkinsfile: Add flake8 . --select=E9,F63,F7,F82 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ node('gpu') {
             stage('Tests') {
                 sh """
                     . .venv-$BUILD_NUMBER/bin/activate
-                    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+                    flake8 `python -c 'import deeppavlov; print(deeppavlov.__path__[0])'` --count --select=E9,F63,F7,F82 --show-source --statistics
                     pytest -v --disable-warnings
                     cd docs
                     make clean

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,7 @@ node('gpu') {
             stage('Tests') {
                 sh """
                     . .venv-$BUILD_NUMBER/bin/activate
+                    flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
                     pytest -v --disable-warnings
                     cd docs
                     make clean

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
     include_package_data=True,
     extras_require={
             'tests': [
+                'flake8',
                 'pytest',
                 'pexpect'],
             'docs': [


### PR DESCRIPTION
On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__python/black__](https://github.com/python/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.