### PR TITLE
 fix: simple_download: make it safer to interrupt downloads

### DIFF
--- a/deeppavlov/core/data/utils.py
+++ b/deeppavlov/core/data/utils.py
@@ -62,6 +62,10 @@ def simple_download(url: str, destination: [Path, str]):
     total_length = int(r.headers.get('content-length', 0))
 
     log.info('Downloading from {} to {}'.format(url, destination))
+
+    if temporary.exists() and temporary.stat().st_size > total_length:
+        temporary.write_bytes(b'')  # clearing temporary file when total_length is inconsistent
+
     with temporary.open('ab') as f:
         done = False
         downloaded = f.tell()
@@ -77,7 +81,7 @@ def simple_download(url: str, destination: [Path, str]):
                     if 'content-length' not in r.headers or \
                             total_length - downloaded != int(r.headers['content-length']):
                         raise RuntimeError(f'It looks like the server does not support resuming '
-                                           f'downloads. Please remove {temporary} and try again')
+                                           f'downloads.')
                 for chunk in r.iter_content(chunk_size=CHUNK):
                     if chunk:  # filter out keep-alive new chunks
                         downloaded += len(chunk)

--- a/deeppavlov/core/data/utils.py
+++ b/deeppavlov/core/data/utils.py
@@ -63,22 +63,30 @@ def simple_download(url: str, destination: [Path, str]):
 
     log.info('Downloading from {} to {}'.format(url, destination))
     with temporary.open('ab') as f:
+        done = False
         downloaded = f.tell()
         if downloaded != 0:
             log.warn(f'Found a partial download {temporary}')
         with tqdm(initial=downloaded, total=total_length, unit='B', unit_scale=True) as pbar:
-            while downloaded < total_length:
+            while not done:
                 if downloaded != 0:
-                    log.warn(f'Download stopped abruptly, trying to resume from {downloaded} to reach {total_length}')
+                    log.warn(f'Download stopped abruptly, trying to resume from {downloaded} '
+                             f'to reach {total_length}')
                     headers['Range'] = f'bytes={downloaded}-'
                     r = requests.get(url, headers=headers, stream=True)
-                    if total_length - downloaded != int(r.headers['content-length']):
-                        raise RuntimeError('It looks like the server does not support resuming downloads')
+                    if 'content-length' not in r.headers or \
+                            total_length - downloaded != int(r.headers['content-length']):
+                        raise RuntimeError(f'It looks like the server does not support resuming '
+                                           f'downloads. Please remove {temporary} and try again')
                 for chunk in r.iter_content(chunk_size=CHUNK):
                     if chunk:  # filter out keep-alive new chunks
                         downloaded += len(chunk)
                         pbar.update(len(chunk))
                         f.write(chunk)
+                if downloaded >= total_length:
+                    # Note that total_length is 0 if the server didn't return the content length,
+                    # in this case we perform just one iteration and assume that we are done.
+                    done = True
 
     temporary.rename(destination)
 

--- a/deeppavlov/core/data/utils.py
+++ b/deeppavlov/core/data/utils.py
@@ -55,7 +55,7 @@ def simple_download(url: str, destination: [Path, str]):
 
     destination = Path(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = destination.with_suffix(".part")
+    temporary = destination.with_suffix(destination.suffix + '.part')
 
     headers = {'dp-token': get_download_token()}
     r = requests.get(url, stream=True, headers=headers)


### PR DESCRIPTION
This PR fixes the `simple_download` function. The problem was that downloads were unsafe to interrupt, because it this cases the partially downloaded file was considered to be fully downloaded. This PR should fix this by downloading into a `*.part` file first and trying to restart the download if such a file exists.