### PR TITLE
fix: fixed wrong model args names

### DIFF
--- a/deeppavlov/utils/server/server.py
+++ b/deeppavlov/utils/server/server.py
@@ -65,11 +65,10 @@ def get_server_params(server_config_path, model_config):
 
     server_params['model_endpoint'] = server_params.get('model_endpoint', '/model')
 
-    chainer_in = model_config['chainer']['in']
-    if isinstance(chainer_in, str):
-        chainer_in = [chainer_in]
-
-    server_params['model_args_names'] = server_params['model_args_names'] or chainer_in
+    arg_names = server_params['model_args_names'] or model_config['chainer']['in']
+    if isinstance(arg_names, str):
+        arg_names = [arg_names]
+    server_params['model_args_names'] = arg_names
 
     return server_params
 

--- a/deeppavlov/utils/server/server.py
+++ b/deeppavlov/utils/server/server.py
@@ -64,7 +64,12 @@ def get_server_params(server_config_path, model_config):
                     server_params[param_name] = model_defaults[param_name]
 
     server_params['model_endpoint'] = server_params.get('model_endpoint', '/model')
-    server_params['model_args_names'] = server_params['model_args_names'] or model_config['chainer']['in']
+
+    chainer_in = model_config['chainer']['in']
+    if isinstance(chainer_in, str):
+        chainer_in = [chainer_in]
+
+    server_params['model_args_names'] = server_params['model_args_names'] or chainer_in
 
     return server_params
 


### PR DESCRIPTION
In some model config model argument name is not in list, that is why rise api instead of making one `question` parameter makes 8 different parameters on every letter of parameter name.