### PR TITLE
chore: checkout PR branch before testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node('cuda-module') {
                 sh "rm -rf .[^.] .??* *"
             }
             stage('Checkout') {
-                sh "cp -r ${pwd()}@script/* ."
+                checkout scm
             }
             stage('Setup') {
                 env.TFHUB_CACHE_DIR="tfhub_cache"


### PR DESCRIPTION
Update Jenkinsfile so that the script would work on both newer and old versions of `GitHub Branch Source Plugin` and would not require Jenkins nodes to share `workspace` directory.