### PR TITLE
Fix bug with tab sep

### DIFF
--- a/deeppavlov/core/data/simple_vocab.py
+++ b/deeppavlov/core/data/simple_vocab.py
@@ -136,7 +136,7 @@ class SimpleVocabulary(Estimator):
             token = ln.strip().split()[0]
             cnt = self._min_freq
         else:
-            token, cnt = ln.split('\t', 1)
+            token, cnt = ln.rsplit('\t', 1)
         return token, cnt
 
     @property


### PR DESCRIPTION
Added the ability to work correctly if the data has a '\t' separator in vocab's value