### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/deeppavlov/models/kbqa/entity_linking.py
+++ b/deeppavlov/models/kbqa/entity_linking.py
@@ -18,7 +18,7 @@ from typing import List, Dict, Tuple, Optional
 
 import nltk
 import pymorphy2
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from deeppavlov.core.common.registry import register
 from deeppavlov.core.models.component import Component

--- a/deeppavlov/models/slotfill/slotfill.py
+++ b/deeppavlov/models/slotfill/slotfill.py
@@ -15,7 +15,7 @@
 import json
 from logging import getLogger
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 from overrides import overrides
 
 from deeppavlov.core.common.registry import register

--- a/deeppavlov/requirements/spelling.txt
+++ b/deeppavlov/requirements/spelling.txt
@@ -1,4 +1,3 @@
 lxml==4.4.2
-python-Levenshtein==0.12.0
 sortedcontainers==2.1.0
 sacremoses==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aio-pika==6.4.1
 Cython==0.29.14
 fastapi==0.47.1
-rapidfuzzy==0.2.1
+rapidfuzz==0.2.1
 h5py==2.10.0
 nltk==3.4.5
 numpy==1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aio-pika==6.4.1
 Cython==0.29.14
 fastapi==0.47.1
-fuzzywuzzy==0.17.0
+rapidfuzzy==0.2.1
 h5py==2.10.0
 nltk==3.4.5
 numpy==1.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aio-pika==6.4.1
 Cython==0.29.14
 fastapi==0.47.1
-rapidfuzz==0.2.1
+rapidfuzz==0.4.0
 h5py==2.10.0
 nltk==3.4.5
 numpy==1.18.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.