### PR TITLE
Fix config for trans_en_mbert

### DIFF
--- a/deeppavlov/configs/squad/trans_en_mbert.json
+++ b/deeppavlov/configs/squad/trans_en_mbert.json
@@ -90,8 +90,8 @@
     "variables": {
       "ROOT_PATH": "~/.deeppavlov",
       "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
-      "MODELS_PATH": "{ROOT_PATH}/models/trans_en_mbert_{PORTION}",
-      "PORTION": "1000"
+      "PORTION": "1000",
+      "MODELS_PATH": "{ROOT_PATH}/models/trans_en_mbert_{PORTION}"
     },
     "requirements": [
       "{DEEPPAVLOV_PATH}/requirements/tf.txt",


### PR DESCRIPTION
Fix `KeyError: 'PORTION'` during install trans_en_mbert