### PR TITLE
fix: add sacremoses to main requirements as it's used a lot

### DIFF
--- a/deeppavlov/requirements/spelling.txt
+++ b/deeppavlov/requirements/spelling.txt
@@ -1,4 +1,3 @@
 lxml==4.4.2
 python-Levenshtein==0.12.0
 sortedcontainers==2.1.0
-sacremoses==0.0.35

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ scikit-learn==0.21.2
 scipy==1.4.1
 tqdm==4.41.1
 uvicorn==0.11.1
+sacremoses==0.0.35


### PR DESCRIPTION
add sacremoses to main requirements.txt because it's used by nltk_tokenizer. nltk_tokenizer is used a lot by different components, and previously it didn't required extra requirements files (sacremoses was initially added only in spelling.txt).