### PR TITLE
feat: allow explicitly skipping datatypes in classification data reader

### DIFF
--- a/deeppavlov/dataset_readers/basic_classification_reader.py
+++ b/deeppavlov/dataset_readers/basic_classification_reader.py
@@ -74,6 +74,9 @@ class BasicClassificationDatasetReader(DatasetReader):
                 "test": []}
         for data_type in data_types:
             file_name = kwargs.get(data_type, '{}.{}'.format(data_type, format))
+            if file_name is None:
+                continue
+            
             file = Path(data_path).joinpath(file_name)
             if file.exists():
                 if format == 'csv':


### PR DESCRIPTION
Should resolve #1218