### PR TITLE
Fix of incorrect lemmatization for Russian names and surnames

### DIFF
--- a/deeppavlov/models/morpho_tagger/lemmatizer.py
+++ b/deeppavlov/models/morpho_tagger/lemmatizer.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 
 import numpy as np
 from pymorphy2 import MorphAnalyzer
+from pymorphy2.analyzer import Parse
 from russian_tagsets import converters
 
 from deeppavlov.core.common.registry import register
@@ -78,9 +79,12 @@ class UDPymorphyLemmatizer(BasicLemmatizer):
     the parse whose tag resembles the most a known UD tag is chosen.
     """
 
+    RARE_FEATURES = ["Fixd", "Litr"]
+    SPECIAL_FEATURES = ["Patr", "Surn"]
+
     def __init__(self, save_path: Optional[str] = None, load_path: Optional[str] = None,
-                 transform_lemmas=False, **kwargs) -> None:
-        self.transform_lemmas = transform_lemmas
+                 rare_grammeme_penalty=1.0, **kwargs) -> None:
+        self.rare_grammeme_penalty = rare_grammeme_penalty
         self._reset()
         self.analyzer = MorphAnalyzer()
         self.converter = converters.converter("opencorpora-int", "ud20")
@@ -95,6 +99,19 @@ class UDPymorphyLemmatizer(BasicLemmatizer):
     def _reset(self):
         self.memo = dict()
 
+    def _extract_lemma(self, parse: Parse) -> str:
+        special_feats = [x for x in self.SPECIAL_FEATURES if x in parse.tag]
+        if len(special_feats) == 0:
+            return parse.normal_form
+        # here we process surnames and patronyms since PyMorphy lemmatizes them incorrectly
+        for other in parse.lexeme:
+            tag = other.tag
+            if any(x not in tag for x in special_feats):
+                continue
+            if tag.case == "nomn" and tag.gender == parse.tag.gender and tag.number == "sing":
+                return other.word
+        return parse.normal_form        
+
     def _lemmatize(self, word: str, tag: Optional[str] = None) -> str:
         lemma = self.memo.get((word, tag))
         if lemma is not None:
@@ -102,10 +119,14 @@ class UDPymorphyLemmatizer(BasicLemmatizer):
         parses = self.analyzer.parse(word)
         best_lemma, best_distance = word, np.inf
         for i, parse in enumerate(parses):
-            curr_tag, curr_lemma = self.converter(str(parse.tag)), parse.normal_form
+            curr_tag = self.converter(str(parse.tag))
             distance = get_tag_distance(tag, curr_tag)
+            for feat in self.RARE_FEATURES:
+                if feat in parse.tag:
+                    distance += self.rare_grammeme_penalty
+                    break
             if distance < best_distance:
-                best_lemma, best_distance = curr_lemma, distance
+                best_lemma, best_distance = self._extract_lemma(parse), distance
                 if distance == 0:
                     break
         self.memo[(word, tag)] = best_lemma

--- a/docs/features/models/popularity_ranking.rst
+++ b/docs/features/models/popularity_ranking.rst
@@ -29,10 +29,9 @@ Building the model
 
 .. code:: python
 
-    from deeppavlov import configs
-    from deeppavlov.core.commands.infer import build_model
+    from deeppavlov import build_model, configs
 
-    ranker = build_model(configs.doc_retrieval.en_ranker_pop_enwiki20180211, load_trained=True)
+    ranker = build_model(configs.doc_retrieval.en_ranker_pop_enwiki20180211, download=True)
 
 Inference
 

--- a/docs/features/models/tfidf_ranking.rst
+++ b/docs/features/models/tfidf_ranking.rst
@@ -26,10 +26,9 @@ Building (if you don't have your own data)
 
 .. code:: python
 
-    from deeppavlov import configs
-    from deeppavlov.core.commands.infer import build_model
+    from deeppavlov import build_model, configs
 
-    ranker = build_model(configs.doc_retrieval.en_ranker_tfidf_wiki, load_trained=True)
+    ranker = build_model(configs.doc_retrieval.en_ranker_tfidf_wiki, download=True)
 
 Inference
 

--- a/docs/features/skills/odqa.rst
+++ b/docs/features/skills/odqa.rst
@@ -27,8 +27,7 @@ Training (if you have your own data)
 
 .. code:: python
 
-    from deeppavlov import configs
-    from deeppavlov.core.commands.train import train_evaluate_model_from_config
+    from deeppavlov import configs, train_evaluate_model_from_config
 
     train_evaluate_model_from_config(configs.doc_retrieval.en_ranker_tfidf_wiki, download=True)
     train_evaluate_model_from_config(configs.squad.multi_squad_noans, download=True)
@@ -37,10 +36,9 @@ Building
 
 .. code:: python
 
-    from deeppavlov import configs
-    from deeppavlov.core.commands.infer import build_model
+    from deeppavlov import build_model, configs
 
-    odqa = build_model(configs.odqa.en_odqa_infer_wiki, load_trained=True)
+    odqa = build_model(configs.odqa.en_odqa_infer_wiki, download=True)
 
 Inference
 


### PR DESCRIPTION
By default, `pymorphy` lemmatizes surnames to masculine form (`ивановой` - `иванов`) and patronyms to names (`ивановича` - `иван`). This PR fixes it by modifying the `UDPymorphyLemmatizer` class.