### PR TITLE
Faq output correction

### DIFF
--- a/deeppavlov/configs/faq/tfidf_logreg_autofaq.json
+++ b/deeppavlov/configs/faq/tfidf_logreg_autofaq.json
@@ -73,7 +73,7 @@
       },
       {
         "in": "y_pred_proba",
-        "out": "y_pred_ids",
+        "out": ["y_pred_ids", "y_pred_proba_max"],
         "class_name": "proba2labels",
         "max_proba": true
       },
@@ -85,7 +85,7 @@
     ],
     "out": [
       "y_pred_answers",
-      "y_pred_proba"
+      "y_pred_proba_max"
     ]
   },
   "train": {

--- a/deeppavlov/configs/faq/tfidf_logreg_en_faq.json
+++ b/deeppavlov/configs/faq/tfidf_logreg_en_faq.json
@@ -72,7 +72,7 @@
       },
       {
         "in": "y_pred_proba",
-        "out": "y_pred_ids",
+        "out": ["y_pred_ids", "y_pred_proba_max"],
         "class_name": "proba2labels",
         "max_proba": true
       },
@@ -84,7 +84,7 @@
     ],
     "out": [
       "y_pred_answers",
-      "y_pred_proba"
+      "y_pred_proba_max"
     ]
   },
   "train": {

--- a/deeppavlov/core/common/metrics_registry.json
+++ b/deeppavlov/core/common/metrics_registry.json
@@ -12,6 +12,7 @@
   "google_bleu": "deeppavlov.metrics.bleu:google_bleu",
   "kbqa_accuracy": "deeppavlov.metrics.accuracy:kbqa_accuracy",
   "log_loss": "deeppavlov.metrics.log_loss:sk_log_loss",
+  "mean_squared_error": "deeppavlov.metrics.mse:mse",
   "multitask_accuracy": "deeppavlov.metrics.accuracy:multitask_accuracy",
   "multitask_sequence_accuracy": "deeppavlov.metrics.accuracy:multitask_sequence_accuracy",
   "multitask_token_accuracy": "deeppavlov.metrics.accuracy:multitask_token_accuracy",

--- a/examples/gobot_md_yaml_configs_tutorial.ipynb
+++ b/examples/gobot_md_yaml_configs_tutorial.ipynb
@@ -5,7 +5,8 @@
     "colab": {
       "name": "gobot_md_yaml_configs_tutorial.ipynb",
       "provenance": [],
-      "toc_visible": true
+      "toc_visible": true,
+      "include_colab_link": true
     },
     "kernelspec": {
       "name": "python3",
@@ -26,6 +27,16 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "view-in-github",
+        "colab_type": "text"
+      },
+      "source": [
+        "<a href=\"https://colab.research.google.com/github/deepmipt/DeepPavlov/blob/master/examples/gobot_md_yaml_configs_tutorial.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "Jj5nbxnPbz6D",
         "colab_type": "text"
       },
@@ -43,7 +54,7 @@
         "At DeepPavlov, we support a variety of industry-wide and popular standards to support developing Conversational AI solutions.\n",
         "DSLs, known as Domain-Specific Languages, provide a rich mechanism to define the behavior, or \"the what\", while\n",
         "the underlying system uses the parser to transform these definitions into commands that implement this behavior, or \"the how\" using the system's components.\n",
-        "Until very recently we supported two such DSLs, including industry-standard [AIML](http://docs.deeppavlov.ai/en/master/features/skills/aiml_skill.html), as well as [DSL](http://docs.deeppavlov.ai/en/master/features/skills/dsl_skill.html) designed by one our partners, EORA.\n",
+        "Until very recently we supported two such DSLs, including industry-standard [AIML](http://docs.deeppavlov.ai/en/master/features/skills/aiml_skill.html), as well as [DSL](http://docs.deeppavlov.ai/en/master/features/skills/dsl_skill.html) designed by one of our partners, EORA.\n",
         "\n",
         "In this tutorial, you will learn how to use another industrial DSL, or, better said, set of DSLs, introduced by RASA.ai,\n",
         "to build simple goal-oriented chatbots using DeepPavlov's GO-bot.\n",
@@ -3321,7 +3332,7 @@
         "outputId": "6b966769-2200-45a3-f446-c6d8afafa7bd"
       },
       "source": [
-        "!wget https://raw.githubusercontent.com/RasaHQ/rasa/master/examples/moodbot/config.yml"
+        "!wget https://raw.githubusercontent.com/RasaHQ/rasa/1.10.x/examples/moodbot/config.yml"
       ],
       "execution_count": null,
       "outputs": [


### PR DESCRIPTION
Для корректной работы следует поменять 2 конфига - tfidf_logreg_autofaq и tfidf_logreg_en. Если изменение конфига это прямо не ок, то можем сделать наше изменение в виде отдельной ноды, чтобы можно было ее просто добавлять в  chainer в кастомных конфигах. Вот)