### PR TITLE
Fix for Paraphraser reader not to give degenerate labels

### DIFF
--- a/deeppavlov/dataset_readers/paraphraser_reader.py
+++ b/deeppavlov/dataset_readers/paraphraser_reader.py
@@ -57,5 +57,5 @@ class ParaphraserReader(DatasetReader):
             if do_lower_case:
                 key = tuple([t.lower() for t in key])
 
-            data[key] = 1 if int(paraphrase.find('value[@name="class"]').text) >= 0 else 0
+            data[key] = 1 if int(paraphrase.find('value[@name="class"]').text) > 0 else 0
         return list(data.items())

--- a/deeppavlov/dataset_readers/paraphraser_reader.py
+++ b/deeppavlov/dataset_readers/paraphraser_reader.py
@@ -57,5 +57,5 @@ class ParaphraserReader(DatasetReader):
             if do_lower_case:
                 key = tuple([t.lower() for t in key])
 
-            data[key] = 1 if int(paraphrase.find('value[@name="class"]').text) > 0 else 0
+            data[key] = int(paraphrase.find('value[@name="class"]').text)
         return list(data.items())


### PR DESCRIPTION
In datasets that are read by paraphrase reader, labels are degenerate. This PR fixes this issue.