### PR TITLE
fix: upload DeepPavlov BERT models with MLM & NSP heads parameters

### DIFF
--- a/deeppavlov/configs/classifiers/sentiment_twitter_bert_emb.json
+++ b/deeppavlov/configs/classifiers/sentiment_twitter_bert_emb.json
@@ -128,7 +128,7 @@
       "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
       "MODELS_PATH": "{ROOT_PATH}/models",
       "MODEL_PATH": "{MODELS_PATH}/classifiers/sentiment_twitter_bert_emb",
-      "BERT_PATH": "{DOWNLOADS_PATH}/bert_models/rubert_cased_L-12_H-768_A-12_pt"
+      "BERT_PATH": "{DOWNLOADS_PATH}/bert_models/rubert_cased_L-12_H-768_A-12_pt_v1"
     },
     "download": [
       {
@@ -136,7 +136,7 @@
         "subdir": "{DOWNLOADS_PATH}"
       },
       {
-        "url": "http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt.tar.gz",
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt_v1.tar.gz",
         "subdir": "{DOWNLOADS_PATH}/bert_models"
       }
     ]

--- a/deeppavlov/configs/classifiers/sentiment_twitter_bert_emb.json
+++ b/deeppavlov/configs/classifiers/sentiment_twitter_bert_emb.json
@@ -39,7 +39,7 @@
       {
         "class_name": "transformers_bert_embedder",
         "id": "my_embedder",
-        "bert_config_path": "{BERT_PATH}/bert_config.json",
+        "bert_config_path": "{BERT_PATH}/config.json",
         "truncate": false,
         "load_path": "{BERT_PATH}",
         "in": ["subword_tok_ids", "startofword_markers", "attention_mask"],

--- a/deeppavlov/configs/embedder/bert_sentence_embedder.json
+++ b/deeppavlov/configs/embedder/bert_sentence_embedder.json
@@ -12,7 +12,7 @@
       },
       {
         "class_name": "transformers_bert_embedder",
-        "bert_config_path": "{BERT_PATH}/bert_config.json",
+        "bert_config_path": "{BERT_PATH}/config.json",
         "load_path": "{BERT_PATH}",
         "truncate": false,
         "in": ["subword_tok_ids", "startofword_markers", "attention_mask"],
@@ -26,12 +26,12 @@
     "variables": {
       "ROOT_PATH": "~/.deeppavlov",
       "DOWNLOADS_PATH": "{ROOT_PATH}/downloads",
-      "BERT_PATH": "{DOWNLOADS_PATH}/bert_models/sentence_multi_cased_L-12_H-768_A-12_pt"
+      "BERT_PATH": "{DOWNLOADS_PATH}/bert_models/sentence_multi_cased_L-12_H-768_A-12_pt_v1"
     },
     "labels": {},
     "download": [
       {
-        "url": "http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz",
+        "url": "http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt_v1.tar.gz",
         "subdir": "{DOWNLOADS_PATH}/bert_models"
       }
     ]

--- a/docs/features/models/bert.rst
+++ b/docs/features/models/bert.rst
@@ -22,13 +22,13 @@ There are several pre-trained BERT models released by Google Research, more deta
 We have trained BERT-base model for other languages and domains:
 
 -  RuBERT, Russian, cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_v2.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 -  SlavicBERT, Slavic (bg, cs, pl, ru), cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_v1.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 -  Conversational BERT, English, cased, 12-layer, 768-hidden, 12-heads, 110M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_v1.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 -  Conversational RuBERT, Russian, cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 -  Conversational DistilRuBERT, Russian, cased, 6-layer, 768-hidden, 12-heads, 135.4M parameters: `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/distil_ru_conversational_cased_L-6_H-768_A-12_pt.tar.gz>`__
 -  Conversational DistilRuBERT-tiny, Russian, cased, 2-layer, 768-hidden, 12-heads, 107M parameters: `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/distil_ru_conversational_cased_L-2_H-768_A-12_pt.tar.gz>`__
 -  Sentence Multilingual BERT, 101 languages, cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,

--- a/docs/features/models/bert.rst
+++ b/docs/features/models/bert.rst
@@ -32,9 +32,9 @@ We have trained BERT-base model for other languages and domains:
 -  Conversational DistilRuBERT, Russian, cased, 6-layer, 768-hidden, 12-heads, 135.4M parameters: `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/distil_ru_conversational_cased_L-6_H-768_A-12_pt.tar.gz>`__
 -  Conversational DistilRuBERT-tiny, Russian, cased, 2-layer, 768-hidden, 12-heads, 107M parameters: `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/distil_ru_conversational_cased_L-2_H-768_A-12_pt.tar.gz>`__
 -  Sentence Multilingual BERT, 101 languages, cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 -  Sentence RuBERT, Russian, cased, 12-layer, 768-hidden, 12-heads, 180M parameters: `[deeppavlov] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12.tar.gz>`__,
-   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__
+   `[deeppavlov_pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__
 
 The ``deeppavlov_pytorch`` models are designed to be run with the `HuggingFace's Transformers <https://huggingface.co/transformers/>`__ library.
 

--- a/docs/features/pretrained_vectors.rst
+++ b/docs/features/pretrained_vectors.rst
@@ -32,16 +32,16 @@ The download links are:
 | Description                | Model parameters                      | Download links                                                                                                     |
 +============================+=======================================+====================================================================================================================+
 | RuBERT                     | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_v2.tar.gz>`__,         |
-|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt.tar.gz>`__             |
+|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__             |
 +----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
 | Slavic BERT                | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_v1.tar.gz>`__,    |
-|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__        |
+|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__        |
 +----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
 | Conversational BERT        | vocab size = 30K, parameters = 110M,  | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_v1.tar.gz>`__, |
-|                            | size = 385MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt.tar.gz>`__     |
+|                            | size = 385MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__     |
 +----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
 | Conversational RuBERT      | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12.tar.gz>`__, |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt.tar.gz>`__  |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__  |
 +----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
 | Sentence Multilingual BERT | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,    |
 |                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz>`__     |

--- a/docs/features/pretrained_vectors.rst
+++ b/docs/features/pretrained_vectors.rst
@@ -44,10 +44,10 @@ The download links are:
 |                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__ |
 +----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 | Sentence Multilingual BERT | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,      |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz>`__       |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__    |
 +----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 | Sentence RuBERT            | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12.tar.gz>`__,         |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__          |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__       |
 +----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 
 

--- a/docs/features/pretrained_vectors.rst
+++ b/docs/features/pretrained_vectors.rst
@@ -28,27 +28,27 @@ The ``TensorFlow`` models can be run with the original `BERT repo <https://githu
 while the ``PyTorch`` models can be run with the `HuggingFace's Transformers <https://github.com/huggingface/transformers>`__ library.
 The download links are:
 
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Description                | Model parameters                      | Download links                                                                                                     |
-+============================+=======================================+====================================================================================================================+
-| RuBERT                     | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_v2.tar.gz>`__,         |
-|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__             |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Slavic BERT                | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_v1.tar.gz>`__,    |
-|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__        |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Conversational BERT        | vocab size = 30K, parameters = 110M,  | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_v1.tar.gz>`__, |
-|                            | size = 385MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__     |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Conversational RuBERT      | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12.tar.gz>`__, |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__  |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Sentence Multilingual BERT | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,    |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz>`__     |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
-| Sentence RuBERT            | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12.tar.gz>`__,       |
-|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__        |
-+----------------------------+---------------------------------------+--------------------------------------------------------------------------------------------------------------------+
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Description                | Model parameters                      | Download links                                                                                                       |
++============================+=======================================+======================================================================================================================+
+| RuBERT                     | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_v2.tar.gz>`__,           |
+|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/rubert_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__            |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Slavic BERT                | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_v1.tar.gz>`__,      |
+|                            | size = 632MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/bg_cs_pl_ru_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__       |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Conversational BERT        | vocab size = 30K, parameters = 110M,  | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_v1.tar.gz>`__,   |
+|                            | size = 385MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__    |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Conversational RuBERT      | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12.tar.gz>`__,   |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/ru_conversational_cased_L-12_H-768_A-12_pt_v1.tar.gz>`__ |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Sentence Multilingual BERT | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12.tar.gz>`__,      |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_multi_cased_L-12_H-768_A-12_pt.tar.gz>`__       |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
+| Sentence RuBERT            | vocab size = 120K, parameters = 180M, | `[tensorflow] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12.tar.gz>`__,         |
+|                            | size = 630MB                          | `[pytorch] <http://files.deeppavlov.ai/deeppavlov_data/bert/sentence_ru_cased_L-12_H-768_A-12_pt.tar.gz>`__          |
++----------------------------+---------------------------------------+----------------------------------------------------------------------------------------------------------------------+
 
 
 ELMo


### PR DESCRIPTION
This PR fixes a problem with pre-trained BERT models by DeepPavlov. Previous checkpoints did not include some weights that are usually used only for pre-training.

Checkpoints from DeepPavlov docs http://docs.deeppavlov.ai/en/master/features/pretrained_vectors.html#bert did not include bias parameter in NSP head.

Checkpoints from HuggingFace https://huggingface.co/DeepPavlov did not include MLM head and NSP head parameters.

Updated checkpoints:

- RuBERT (DeepPavlov/rubert-base-cased)
- Slavic BERT (DeepPavlov/bert-base-bg-cs-pl-ru-cased)
- Conversational BERT (DeepPavlov/bert-base-cased-conversational)
- Conversational RuBERT (DeepPavlov/rubert-base-cased-conversational)

Also, tokenizer configuration (tokenizer_config.json) was added to every [DeepPavlov BERT model](http://docs.deeppavlov.ai/en/master/features/pretrained_vectors.html#downloads).

TODO:
- [x] update urls in DeepPavlov docs
- [x] upload fixed models to HF 

Related issues and discussions:
- https://github.com/deepmipt/DeepPavlov/issues/1275
- https://github.com/huggingface/transformers/issues/5806
- https://forum.deeppavlov.ai/t/rubert/963
- https://forum.deeppavlov.ai/t/rubert/305/2
- https://opendatascience.slack.com/archives/C04N3UMSL/p1586900942057100