### PR TITLE
fix: en_core_web_sm load error during tests

### DIFF
--- a/deeppavlov/models/kbqa/sentence_answer.py
+++ b/deeppavlov/models/kbqa/sentence_answer.py
@@ -12,13 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import re
 from logging import getLogger
 
+import pkg_resources
 import spacy
 
 log = getLogger(__name__)
 
+# en_core_web_sm installed and used by test_inferring_pretrained_model in the same interpreter session during tests.
+# Spacy checks en_core_web_sm package presence with pkg_resources, but pkg_resources is initialized with interpreter,
+# sot it doesn't see en_core_web_sm installed after interpreter initialization, so we use importlib.reload below.
+
+if 'en-core-web-sm' not in pkg_resources.working_set.by_key.keys():
+    importlib.reload(pkg_resources)
+
+# TODO: move nlp to sentence_answer, sentence_answer to rel_ranking_bert_infer and revise en_core_web_sm requirement
 nlp = spacy.load('en_core_web_sm')
 
 pronouns = ["who", "what", "when", "where", "how"]

--- a/deeppavlov/models/kbqa/sentence_answer.py
+++ b/deeppavlov/models/kbqa/sentence_answer.py
@@ -21,7 +21,7 @@ import spacy
 
 log = getLogger(__name__)
 
-# en_core_web_sm installed and used by test_inferring_pretrained_model in the same interpreter session during tests.
+# en_core_web_sm is installed and used by test_inferring_pretrained_model in the same interpreter session during tests.
 # Spacy checks en_core_web_sm package presence with pkg_resources, but pkg_resources is initialized with interpreter,
 # sot it doesn't see en_core_web_sm installed after interpreter initialization, so we use importlib.reload below.
 


### PR DESCRIPTION
`en_core_web_sm` is installed and used by test_inferring_pretrained_model in the same interpreter session during tests.
Spacy checks en_core_web_sm package presence with pkg_resources, but pkg_resources is initialized with interpreter,
sot it doesn't see en_core_web_sm installed after interpreter initialization.