### PR TITLE
refactor: riseapi mode response format

### DIFF
--- a/deeppavlov/models/api_requester/api_requester.py
+++ b/deeppavlov/models/api_requester/api_requester.py
@@ -33,14 +33,16 @@ class ApiRequester(Component):
 
     Attributes:
         url: url of the API.
-        out: count of expected returned values.
+        out_count: count of expected returned values.
         param_names: list of parameter names for API requests.
         debatchify: if True, single instances will be sent to the API endpoint instead of batches.
     """
 
-    def __init__(self, url: str, out: [int, list], param_names: [list, tuple] = (), debatchify: bool = False,
+    def __init__(self, url: str, out: [int, list], param_names: [list, tuple] = None, debatchify: bool = False,
                  *args, **kwargs):
         self.url = url
+        if param_names is None:
+            param_names = kwargs.get('in', ())
         self.param_names = param_names
         self.out_count = out if isinstance(out, int) else len(out)
         self.debatchify = debatchify
@@ -70,12 +72,10 @@ class ApiRequester(Component):
 
             loop = asyncio.get_event_loop()
             response = loop.run_until_complete(collect())
-
+            if self.out_count > 1:
+                response = list(zip(*response))
         else:
             response = requests.post(self.url, json=data).json()
-
-        if self.out_count > 1:
-            response = list(zip(*response))
 
         return response
 

--- a/docs/integrations/rest_api.rst
+++ b/docs/integrations/rest_api.rst
@@ -24,6 +24,13 @@ The command will print the used host and port. Default web service properties
 (host, port, POST request arguments) can be modified via changing
 ``deeppavlov/utils/settings/server_config.json`` file.
 
+.. warning::
+
+    Starting from the 1.0.0rc2 model response format in riseapi mode matches :class:`~deeppavlov.core.common.chainer.Chainer`
+    response format. To start model with the old format, give the ``COMPATIBILITY_MODE`` environment variable any
+    non-empty value (e.g. ``COMPATIBILITY_MODE=true python -m deeppavlov riseapi ...``).
+    ``COMPATIBILITY_MODE`` will be removed in DeepPavlov 1.2.0.
+
 API routes
 ----------
 
@@ -40,8 +47,8 @@ server will send a response ``["Test passed"]`` if it is working. Requests to
 
 /api
 """"
-To get model argument names send GET request to ``<host>:<port>/api``. Server
-will return list with argument names.
+To get model argument and response names send GET request to ``<host>:<port>/api``. Server
+will return dict with model input and output names.
 
 .. _rest_api_docs:
 

--- a/tests/test_quick_start.py
+++ b/tests/test_quick_start.py
@@ -444,7 +444,7 @@ class TestQuickStart(object):
             response_code = get_response.status_code
             assert response_code == 200, f"GET /api request returned error code {response_code} with {config_path}"
 
-            model_args_names = get_response.json()
+            model_args_names = get_response.json()['in']
             post_payload = dict()
             for arg_name in model_args_names:
                 arg_value = ' '.join(['qwerty'] * 10)


### PR DESCRIPTION
If Chainer returns `["a0", "a1", "a2"]`, riseapi response format is changed from `[["a0"], ["a1"], ["a2"]]` to `["a0", "a1", "a2"]`.
If Chainer returns `(["a0", "a1", "a2"], ["b0", "b1", "b2"])`, riseapi response format is changed from `[["a0", "b0"], ["a1", "b1"], ["a2", "b2"]]` to `[["a0", "a1", "a2"], ["b0", "b1", "b2"]]`.